### PR TITLE
機密性の高いフィールドはAPIから返さない

### DIFF
--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -26,6 +26,11 @@ services:
         tags:
             - { name: kernel.event_listener, event: trikoder.oauth2.user_resolve, method: onUserResolve }
 
+    Plugin\Api\GraphQL\Types:
+        class: Plugin\Api\GraphQL\Types
+        arguments: ["@doctrine.orm.entity_manager"]
+        lazy: true
+
     # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
     Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
     Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'

--- a/Tests/GraphQL/TypesTest.php
+++ b/Tests/GraphQL/TypesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\Tests\GraphQL;
+
+use Eccube\Entity\BaseInfo;
+use Eccube\Entity\Customer;
+use Eccube\Entity\Member;
+use Eccube\Entity\Product;
+use Eccube\Tests\EccubeTestCase;
+use Plugin\Api\GraphQL\Types;
+
+class TypesTest extends EccubeTestCase
+{
+    /** @var Types */
+    private $types;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->types = $this->container->get(Types::class);
+    }
+
+    /**
+     * @dataProvider hideSensitiveFieldsProvider
+     */
+    public function testHideSensitiveFields($entityClass, $field, $expectExists)
+    {
+        $type = $this->types->get($entityClass);
+
+        self::assertEquals($expectExists, $type->hasField($field));
+    }
+
+    public function hideSensitiveFieldsProvider()
+    {
+        return [
+            [Product::class, 'name', true],
+            [Customer::class, 'name01', true],
+            [Customer::class, 'password', false],
+            [Customer::class, 'reset_key', false],
+            [Customer::class, 'salt', false],
+            [Customer::class, 'secret_key', false],
+            [Member::class, 'name', true],
+            [Member::class, 'password', false],
+            [Member::class, 'salt', false],
+            [BaseInfo::class, 'authentication_key', false],
+        ];
+    }
+}

--- a/Tests/Web/Admin/LoginControllerTest.php
+++ b/Tests/Web/Admin/LoginControllerTest.php
@@ -14,6 +14,7 @@
 namespace Plugin\Api\Tests\Web\Admin;
 
 use Eccube\Tests\Web\AbstractWebTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class LoginControllerTest extends AbstractWebTestCase
 {
@@ -43,15 +44,13 @@ class LoginControllerTest extends AbstractWebTestCase
         $this->assertNotNull($this->container->get('security.token_storage')->getToken(), 'ログインしているかどうか');
     }
 
-    public function testRoutingAdminLogin_ログインしていない場合は401エラーがかえる()
+    public function testRoutingAdminLogin_ログインしていない場合はログイン画面を表示()
     {
         $this->client->request('GET', $this->generateUrl('admin_homepage'));
 
         // ログイン
-        $this->assertEquals(
-            401,
-            $this->client->getResponse()->getStatusCode()
-        );
+        self::assertTrue($this->client->getResponse()->isRedirect(
+            $this->generateUrl('admin_login', [], UrlGeneratorInterface::ABSOLUTE_URL)));
     }
 
     public function testRoutingAdminOauth2Authorize_ログインしていない場合はログイン画面を表示()
@@ -59,10 +58,8 @@ class LoginControllerTest extends AbstractWebTestCase
         $this->client->request('GET', $this->generateUrl('admin_oauth2_authorize'));
 
         // ログイン
-        $this->assertEquals(
-            401,
-            $this->client->getResponse()->getStatusCode()
-        );
+        self::assertTrue($this->client->getResponse()->isRedirect(
+            $this->generateUrl('admin_login', [], UrlGeneratorInterface::ABSOLUTE_URL)));
     }
 
     public function testRoutingOauth2Authorize_ログインしていない場合はログイン画面を表示()
@@ -70,9 +67,7 @@ class LoginControllerTest extends AbstractWebTestCase
         $this->client->request('GET', $this->generateUrl('oauth2_authorize'));
 
         // ログイン
-        $this->assertEquals(
-            401,
-            $this->client->getResponse()->getStatusCode()
-        );
+        self::assertTrue($this->client->getResponse()->isRedirect(
+            $this->generateUrl('admin_login', [], UrlGeneratorInterface::ABSOLUTE_URL)));
     }
 }


### PR DESCRIPTION
以下のDBカラムを返さないように修正
- dtb_base_info.authentication_key
- dtb_customer.password
- dtb_customer.reset_key
- dtb_customer.salt
- dtb_customer.secret_key
- dtb_member.password
- dtb_menber.salt
#4 
