### PR TITLE
Grant を authorization code / refresh token grant に制限

### DIFF
--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -10,6 +10,21 @@ trikoder_oauth2:
         private_key_passphrase: null
         encryption_key: '%env(ECCUBE_OAUTH2_ENCRYPTION_KEY)%'
 
+      # Whether to enable the client credentials grant
+        enable_client_credentials_grant: false
+
+      # Whether to enable the password grant
+        enable_password_grant: false
+
+      # Whether to enable the refresh token grant
+        enable_refresh_token_grant: true
+
+      # Whether to enable the authorization code grant
+        enable_auth_code_grant: true
+
+      # Whether to enable the implicit grant
+        enable_implicit_grant: false
+
     resource_server:
         public_key: '%env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY)%'
 


### PR DESCRIPTION
Grant を authorization code / refresh token grant に制限しました。

手元の API クライアントで Grant が制限されていることを確認しています。

![image](https://user-images.githubusercontent.com/16895409/86718473-14fff900-c05e-11ea-852c-4a019f594293.png)

![image](https://user-images.githubusercontent.com/16895409/86718544-26490580-c05e-11ea-8e67-a863f604a86e.png)

### 有効な Grant

- authorization code grant
- refresh token grant

### 無効な Grant

- client credentials grant
- password grant
- implicit grant

## その他

`trikoder/oauth2-bundle` の 3.x 以降で code challenge for public clients が利用できるようです。
ただ、 Symfony 4.4 以上でしか動かないようですので EC-CUBE 4.1 で期待です。。。

https://github.com/trikoder/oauth2-bundle
