### PR TITLE
日付を取得できるようにした

### DIFF
--- a/GraphQL/Type/Definition/DateTimeType.php
+++ b/GraphQL/Type/Definition/DateTimeType.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\GraphQL\Type\Definition;
+
+use DateTime;
+use DateTimeInterface;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\Utils;
+
+class DateTimeType extends ScalarType
+{
+    private static $DateTimeType;
+
+    /**
+     * @var string
+     */
+    public $name = 'DateTime';
+
+    /**
+     * @var string
+     */
+    public $description = 'The `DateTime` scalar type represents time data, represented as an ISO-8601 encoded UTC date string.';
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function serialize($value)
+    {
+        if (!$value instanceof DateTimeInterface) {
+            throw new InvariantViolation('DateTime is not an instance of DateTimeInterface: '.Utils::printSafe($value));
+        }
+
+        return $value->format(DateTime::ATOM);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return DateTime|false|null
+     */
+    public function parseValue($value)
+    {
+        return DateTime::createFromFormat(DateTime::ATOM, $value) ?: null;
+    }
+
+    /**
+     * @param Node $valueNode
+     * @param array|null $variables
+     *
+     * @return string|null
+     */
+    public function parseLiteral($valueNode, ?array $variables = null)
+    {
+        if ($valueNode instanceof StringValueNode) {
+            return $valueNode->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @api
+     */
+    public static function DateTime(): ScalarType
+    {
+        if (static::$DateTimeType === null) {
+            static::$DateTimeType = new DateTimeType();
+        }
+
+        return static::$DateTimeType;
+    }
+}

--- a/GraphQL/Types.php
+++ b/GraphQL/Types.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use Plugin\Api\GraphQL\Type\Definition\DateTimeType;
 
 /**
  * DoctrineのEntityからGraphQLのObjectTypeを変換するクラス.
@@ -108,7 +109,7 @@ class Types
             'text' => Type::string(),
             'integer' => Type::int(),
             'decimal' => Type::float(),
-            'datetimetz' => Type::int(),
+            'datetimetz' => DateTimeType::DateTime(),
             'smallint' => Type::int(),
             'boolean' => Type::boolean(),
         ][$fieldMapping['type']];


### PR DESCRIPTION
close #27

DateTime を扱う `DateTimeType ` を独自に実装した。

日付のフォーマットは `DateTime::ATOM = "Y-m-d\TH:i:sP"` とした
https://www.php.net/manual/ja/class.datetimeinterface.php#datetime.constants.atom

> DateTimeInterface::ATOM
> Atom (例: 2005-08-15T15:52:01+00:00)

`DateTimeInterface::RFC3339_EXTENDED` でミリ秒まで返せるが、そもそもDBでミリ秒まで管理できていないので `000` となってしまうので対応していない。

▼参考にしたIssue
https://github.com/webonyx/graphql-php/issues/228#issuecomment-356957616

▼参考にしたドキュメント
https://webonyx.github.io/graphql-php/type-system/scalar-types/

request

```graphql
query getOrders {
  products {
    id
    create_date
    update_date
  }
}
```

responce

```json
{
  "data": {
    "products": [
      {
        "id": "5",
        "create_date": "2020-07-13T17:40:50+09:00",
        "update_date": "2020-07-13T17:42:18+09:00"
      },
      {
        "id": "4",
        "create_date": "2020-07-07T16:26:18+09:00",
        "update_date": "2020-07-07T16:26:18+09:00"
      },
      {
        "id": "3",
        "create_date": "2020-07-07T15:27:17+09:00",
        "update_date": "2020-07-07T15:27:17+09:00"
      },
      {
        "id": "1",
        "create_date": "2018-09-28T19:14:52+09:00",
        "update_date": "2018-09-28T19:14:52+09:00"
      },
      {
        "id": "2",
        "create_date": "2018-09-28T19:14:52+09:00",
        "update_date": "2018-09-28T19:14:52+09:00"
      }
    ]
  }
}
```