### PR TITLE
paging の実装

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -155,7 +155,7 @@ class ApiController extends AbstractController
         ];
         $args['limit'] = [
             'type' => Type::int(),
-            'defaultValue' => null,
+            'defaultValue' => $this->eccubeConfig->get('eccube_default_page_count'),
             'description' => trans('api.args.limit.description'),
         ];
 
@@ -166,13 +166,7 @@ class ApiController extends AbstractController
                 $form = $builder->getForm();
                 $data = FormUtil::submitAndGetData($form, $args);
 
-                if (is_null($args['limit'])) {
-                    // limit が指定されていなければ全件返す
-                    return $resolver($data)->getQuery()->getResult();
-                } else {
-                    // limit が指定されていればその件数返す
-                    return $this->paginator->paginate($resolver($data), $args['page'], $args['limit']);
-                }
+                return $this->paginator->paginate($resolver($data), $args['page'], $args['limit']);
             },
         ];
     }

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -24,7 +24,6 @@ use Eccube\Repository\CustomerRepository;
 use Eccube\Repository\OrderRepository;
 use Eccube\Repository\ProductRepository;
 use GraphQL\Error\DebugFlag;
-use GraphQL\Error\InvariantViolation;
 use GraphQL\GraphQL;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
@@ -181,14 +180,6 @@ class ApiController extends AbstractController
             'resolve' => function ($root, $args) use ($builder, $resolver) {
                 $form = $builder->getForm();
                 $form->submit($args);
-                if (!$form->isValid()) {
-                    $message = 'Invalid error: ';
-                    foreach ($form->getErrors(true) as $error) {
-                        $message .= sprintf('%s: %s;', $error->getOrigin()->getName(), $error->getMessage());
-                    }
-
-                    throw new InvariantViolation($message);
-                }
                 $data = $form->getData();
 
                 return $this->paginator->paginate($resolver($data), $args['page'], $args['limit']);

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -30,6 +30,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use Knp\Component\Pager\Paginator;
+use Plugin\Api\GraphQL\Type\EdgesType;
 use Plugin\Api\GraphQL\Types;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -175,7 +176,7 @@ class ApiController extends AbstractController
         }, []);
 
         return [
-            'type' => Type::listOf($this->types->get($entityClass)),
+            'type' => new EdgesType($entityClass, $this->types),
             'args' => $args,
             'resolve' => function ($root, $args) use ($builder, $resolver) {
                 $form = $builder->getForm();

--- a/GraphQL/Type/ConnectionType.php
+++ b/GraphQL/Type/ConnectionType.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\GraphQL\Type;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+use Plugin\Api\GraphQL\Types;
+
+class ConnectionType extends ObjectType
+{
+    public function __construct(string $className, Types $types)
+    {
+        $config = [
+            'name' => $className.'Connection',
+            'fields' => [
+                'edges' => [
+                    'type' => Type::listOf(new EdgeType($className, $types)),
+                    'resolve' => function ($root) {
+                        return $root;
+                    },
+                ],
+                'nodes' => [
+                    'type' => Type::listOf($types->get($className)),
+                    'resolve' => function ($root) {
+                        return $root;
+                    },
+                ],
+                'pageInfo' => [
+                    'type' => Type::nonNull(new PageInfoType($className)),
+                    'resolve' => function ($root) {
+                        return $root;
+                    },
+                ],
+                'totalCount' => [
+                    'type' => Type::nonNull(Type::int()),
+                    'resolve' => function (PaginationInterface $pagination) {
+                        return $pagination->getTotalItemCount();
+                    },
+                ],
+            ],
+        ];
+        parent::__construct($config);
+    }
+}

--- a/GraphQL/Type/Definition/DateTimeType.php
+++ b/GraphQL/Type/Definition/DateTimeType.php
@@ -77,7 +77,7 @@ class DateTimeType extends ScalarType
     /**
      * @api
      */
-    public static function DateTime(): ScalarType
+    public static function dateTime(): ScalarType
     {
         if (static::$DateTimeType === null) {
             static::$DateTimeType = new DateTimeType();

--- a/GraphQL/Type/EdgeType.php
+++ b/GraphQL/Type/EdgeType.php
@@ -1,28 +1,31 @@
 <?php
 
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Plugin\Api\GraphQL\Type;
-
 
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api\GraphQL\Types;
 
-class EdgesType extends ObjectType
+class EdgeType extends ObjectType
 {
     public function __construct(string $className, Types $types)
     {
         $config = [
-            'name' => $className,
+            'name' => $className.'Edge',
             'fields' => [
-                'edges' => [
-                    'type' => Type::listOf($types->get($className)),
-                    'resolve' => function ($root) {
-                        return $root;
-                    },
-                ],
-                'pageInfo' => [
-                    'type' => new PageInfoType($className),
+                'node' => [
+                    'type' => $types->get($className),
                     'resolve' => function ($root) {
                         return $root;
                     },

--- a/GraphQL/Type/EdgesType.php
+++ b/GraphQL/Type/EdgesType.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Plugin\Api\GraphQL\Type;
+
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use Plugin\Api\GraphQL\Types;
+
+class EdgesType extends ObjectType
+{
+    public function __construct(string $className, Types $types)
+    {
+        $config = [
+            'name' => $className,
+            'fields' => [
+                'edges' => [
+                    'type' => Type::listOf($types->get($className)),
+                    'resolve' => function ($root) {
+                        return $root;
+                    },
+                ],
+                'pageInfo' => [
+                    'type' => new PageInfoType($className),
+                    'resolve' => function ($root) {
+                        return $root;
+                    },
+                ],
+            ],
+        ];
+        parent::__construct($config);
+    }
+}

--- a/GraphQL/Type/PageInfoType.php
+++ b/GraphQL/Type/PageInfoType.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\GraphQL\Type;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+
+class PageInfoType extends ObjectType
+{
+    public function __construct(string $className)
+    {
+        $config = [
+            'name' => $className.'PageInfo',
+            'fields' => function () {
+                return [
+                    'totalCount' => [
+                        'type' => Type::int(),
+                        'resolve' => function (PaginationInterface $pagination) {
+                            return $pagination->getTotalItemCount();
+                        },
+                    ],
+                    'hasNextPage' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function (PaginationInterface $pagination) {
+                            return isset($pagination->getPaginationData()['next']);
+                        },
+                    ],
+                    'hasPreviousPage' => [
+                        'type' => Type::boolean(),
+                        'resolve' => function (PaginationInterface $pagination) {
+                            return isset($pagination->getPaginationData()['previous']);
+                        },
+                    ],
+                ];
+            },
+        ];
+        parent::__construct($config);
+    }
+}

--- a/GraphQL/Type/PageInfoType.php
+++ b/GraphQL/Type/PageInfoType.php
@@ -25,20 +25,14 @@ class PageInfoType extends ObjectType
             'name' => $className.'PageInfo',
             'fields' => function () {
                 return [
-                    'totalCount' => [
-                        'type' => Type::int(),
-                        'resolve' => function (PaginationInterface $pagination) {
-                            return $pagination->getTotalItemCount();
-                        },
-                    ],
                     'hasNextPage' => [
-                        'type' => Type::boolean(),
+                        'type' => Type::nonNull(Type::boolean()),
                         'resolve' => function (PaginationInterface $pagination) {
                             return isset($pagination->getPaginationData()['next']);
                         },
                     ],
                     'hasPreviousPage' => [
-                        'type' => Type::boolean(),
+                        'type' => Type::nonNull(Type::boolean()),
                         'resolve' => function (PaginationInterface $pagination) {
                             return isset($pagination->getPaginationData()['previous']);
                         },

--- a/GraphQL/Types.php
+++ b/GraphQL/Types.php
@@ -109,7 +109,7 @@ class Types
             'text' => Type::string(),
             'integer' => Type::int(),
             'decimal' => Type::float(),
-            'datetimetz' => DateTimeType::DateTime(),
+            'datetimetz' => DateTimeType::dateTime(),
             'smallint' => Type::int(),
             'boolean' => Type::boolean(),
         ][$fieldMapping['type']];

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -2,7 +2,6 @@ parameters:
     env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY): '%kernel.project_dir%/var/oauth/private.key'
     env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY): '%kernel.project_dir%/var/oauth/public.key'
     env(ECCUBE_OAUTH2_ENCRYPTION_KEY): '<change.me>'
-    api_default_paginator_limit: 1000
 
 trikoder_oauth2:
 

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -2,6 +2,7 @@ parameters:
     env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY): '%kernel.project_dir%/var/oauth/private.key'
     env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY): '%kernel.project_dir%/var/oauth/public.key'
     env(ECCUBE_OAUTH2_ENCRYPTION_KEY): '<change.me>'
+    api_default_paginator_limit: 1000
 
 trikoder_oauth2:
 

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -12,3 +12,10 @@ api.admin.setting.system.oauth.client_registration: Client Registration
 api.admin.setting.system.oauth.delete__confirm_title: Delete a Client
 api.admin.setting.system.oauth.delete__confirm_message: Are you sure to delete this Client?
 api.admin.setting.system.oauth.clear_expired_tokens: Clears all expired access and/or refresh tokens
+
+#------------------------------------------------------------------------------------
+# API : Description
+#------------------------------------------------------------------------------------
+
+api.args.page.description: Page number
+api.args.limit.description: Limit number of acquisitions

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -18,4 +18,4 @@ api.admin.setting.system.oauth.clear_expired_tokens: Clears all expired access a
 #------------------------------------------------------------------------------------
 
 api.args.page.description: Page number
-api.args.limit.description: Limit number of acquisitions
+api.args.limit.description: Limit number per page

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -18,4 +18,4 @@ api.admin.setting.system.oauth.clear_expired_tokens: 期限切れのアクセス
 #------------------------------------------------------------------------------------
 
 api.args.page.description: ページ番号
-api.args.limit.description: 取得件数
+api.args.limit.description: ページあたりの取得数の上限

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -12,3 +12,10 @@ api.admin.setting.system.oauth.client_registration: OAuthクライアント登�
 api.admin.setting.system.oauth.delete__confirm_title: OAuthクライアントを削除します。
 api.admin.setting.system.oauth.delete__confirm_message: OAuthクライアントを削除してよろしいですか？
 api.admin.setting.system.oauth.clear_expired_tokens: 期限切れのアクセストークンとリフレッシュトークンを削除する
+
+#------------------------------------------------------------------------------------
+# API：説明
+#------------------------------------------------------------------------------------
+
+api.args.page.description: ページ番号
+api.args.limit.description: 取得件数


### PR DESCRIPTION
close #30 

ページング機能を追加しました。
既存のグラフ構造では実現が難しかったので大きく変更しています。
管理画面の検索機能と同様に `page`, `limit` のパラメータを指定することでページごとの取得が可能です。

最終的な実行例は以下のコメントを参照
https://github.com/EC-CUBE/eccube-api4/pull/32#issuecomment-660825380

<details>

Query例

```GraphQL
query {
  products (page: "2", limit: "3") {
    edges {
      id
      name
    }
    pageInfo {
      totalCount
      hasNextPage
      hasPreviousPage
    }
  }
  customers (page: "1", limit: "3", multi: "440", customer_status: ["3"]) {
    edges {
      id
      name01
      name02
    }
    pageInfo {
      totalCount
      hasNextPage
      hasPreviousPage
    }
  }
}
```

Response例

```json
{
  "data": {
    "products": {
      "edges": [
        {
          "id": "528",
          "name": "河ぎんががらんとうについていままたために、向むこうように見えないところ、細ほそながら何がそのうし。"
        },
        {
          "id": "527",
          "name": "いながられたぬれた天の川の波なみちを、し。"
        },
        {
          "id": "529",
          "name": "の野原かわけられているか、あ。"
        }
      ],
      "pageInfo": {
        "totalCount": 532,
        "hasNextPage": true,
        "hasPreviousPage": true
      }
    },
    "customers": {
      "edges": [
        {
          "id": "440",
          "name01": "山口",
          "name02": "さゆり"
        }
      ],
      "pageInfo": {
        "totalCount": 1,
        "hasNextPage": false,
        "hasPreviousPage": false
      }
    }
  }
}
```

</details>

## 実装に関する補足

### 検索条件の命名について

  - `api_` のプレフィックスをつけるべきか
  - EC-CUBE の内部で利用されている `page_no`, `page_count` に統一すべきか

で悩みましたが、現状他で利用されていないことと、APIでスタンダードな名前が良いと判断し、それぞれ `page`, `limit` とした。

### 検索条件の初期値について

ページングの初期値は管理画面と同様に以下とした

- `page`: 1
- `limit`: 50

またその他の検索条件もデフォルトで管理画面の検索条件を有効にしました。
例えば会員ステータスを指定なしで検索時に「退会」が取得結果に含まれないようになりました。

### 検索条件のエラーハンドリング #35 

検索条件にバリデーションエラーがあった場合にエラーメッセージを返すようにしました。

### 検索条件のエラーハンドリング #36

デバッグモードで実行するとエラー発生時にスタックトレースなどの情報が返るようにしました。

### Types/Type は static にしたかった

Types/Type は static にしたかったがentityManagerなど利用しているため対応しきれずEdgesTypeのconstructなど微妙な作りになっているところがある。

## その他

- GraphQLのデバッグモードを導入しました。環境変数の `APP_DEBUG` で切り替えられます。
- GraphQLのvariablesに対応しました。
