### PR TITLE
プラグイン無効時にはConvertExceptionToResponseListenerを外す

### DIFF
--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -26,6 +26,12 @@ class ApiCompilerPass implements CompilerPassInterface
     {
         $this->configureAllowList($container);
         $this->configureKeyPair($container);
+
+        $plugins = $container->getParameter('eccube.plugins.enabled');
+        if (!in_array('Api', $plugins)) {
+            $def = $container->getDefinition('Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener');
+            $def->clearTags();
+        }
     }
 
     private function configureAllowList(ContainerBuilder $container)

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -29,8 +29,10 @@ class ApiCompilerPass implements CompilerPassInterface
 
         $plugins = $container->getParameter('eccube.plugins.enabled');
         if (!in_array('Api', $plugins)) {
-            $def = $container->getDefinition('Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener');
-            $def->clearTags();
+            if ($container->hasDefinition('Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener')) {
+                $def = $container->getDefinition('Trikoder\Bundle\OAuth2Bundle\EventListener\ConvertExceptionToResponseListener');
+                $def->clearTags();
+            }
         }
     }
 


### PR DESCRIPTION
- fixes https://github.com/EC-CUBE/eccube-api4/issues/26
- https://github.com/EC-CUBE/ec-cube/pull/4625 と共に必要