### PR TITLE
OpenSSLの関数チェックとディレクトリ・ファイルが生成時のエラー処理の追加

### DIFF
--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -68,6 +68,10 @@ class ApiCompilerPass implements CompilerPassInterface
 
     private function generateKeys($privateKeyPath, $publicKeyPath)
     {
+        if (false === function_exists('openssl_pkey_new')) {
+            throw new \RuntimeException('OpenSSL extension not available');
+        }
+
         $res = openssl_pkey_new([
             'digest_alg' => 'sha512',
             'private_key_bits' => 4096,
@@ -80,11 +84,17 @@ class ApiCompilerPass implements CompilerPassInterface
 
         foreach ([$privateKeyPath, $publicKeyPath] as $file) {
             $dir = dirname($file);
-            if (!file_exists($dir)) {
-                mkdir($dir, 0755, true);
+            if (!file_exists($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
+                throw new \RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
         }
-        file_put_contents($privateKeyPath, $privateKey);
-        file_put_contents($publicKeyPath, $publicKey);
+
+        if (false === file_put_contents($privateKeyPath, $privateKey)) {
+            throw new \RuntimeException('File "%s" was not created', $privateKeyPath);
+        }
+
+        if (false === file_put_contents($publicKeyPath, $publicKey)) {
+            throw new \RuntimeException('File "%s" was not created', $publicKeyPath);
+        }
     }
 }


### PR DESCRIPTION
`ApiComplierPass:: generateKeys()` で気になる部分を対応しました。

## 対応箇所
- publicKey, privateKey生成時のディレクトリ・ファイルの生成に失敗した場合にExceptionを発生させる
- OpenSSL Supportがない環境も念の為考慮して `function_exists` でopenssl関数があるかをチェックさせた