### PR TITLE
検索条件のバリデーションエラーをレスポンスに返すように

### DIFF
--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -184,7 +184,7 @@ class ApiController extends AbstractController
                 $form->submit($args);
 
                 if (!$form->isValid()) {
-                    $message = 'Invalid error: ';
+                    $message = '';
                     foreach ($form->getErrors(true) as $error) {
                         $message .= sprintf('%s: %s;', $error->getOrigin()->getName(), $error->getMessage());
                     }

--- a/GraphQL/Error/FormInvalidException.php
+++ b/GraphQL/Error/FormInvalidException.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Plugin\Api\GraphQL\Error;
+
+
+use GraphQL\Error\ClientAware;
+
+class FormInvalidException extends \Exception implements ClientAware
+{
+
+    public function isClientSafe()
+    {
+        return true;
+    }
+
+    public function getCategory()
+    {
+        return 'Invalid argument';
+    }
+}


### PR DESCRIPTION
close https://github.com/EC-CUBE/eccube-api4/issues/35

https://github.com/EC-CUBE/eccube-api4/pull/32 の続きで開発をしていますのでそちらを先に取り込みをお願いします。
差分が多く出ていますが、本件に関する修正点は最後のcommitだけです。

## 実装に関する補足

リゾルバ内で発生したエラーは情報漏洩を避けるために全て "Internal server error" となります。
Formでのバリデーションエラーは登録者に伝えるためのもので、レスポンスに含めても問題ないかと思います。

問題ないエラーであることを明確に定義するため FormInvalidException を定義して throw しています。

参考
https://webonyx.github.io/graphql-php/error-handling/#default-error-formatting

