### PR TITLE
trigger データに不整合がある場合でもエラーが発生しないように修正

### DIFF
--- a/Service/CoreEntityTrigger.php
+++ b/Service/CoreEntityTrigger.php
@@ -44,7 +44,7 @@ class CoreEntityTrigger implements WebHookTrigger
         } elseif ($entity instanceof ProductTag) {
             return $entity->getProduct();
         } elseif ($entity instanceof ProductStock) {
-            return $entity->getProductClass()->getProduct();
+            return is_null($entity->getProductClass()) ? null : $entity->getProductClass()->getProduct();
         } elseif ($entity instanceof TaxRule) {
             return $entity->getProduct();
         } elseif ($entity instanceof ProductImage) {


### PR DESCRIPTION
ジェネレータでデータ作成時に `$entity->getProductClass()` が未設定でflushされることがあり、イベントが発生してエラーが発生していたのでnullのチェックを追加した。