### PR TITLE
出荷情報を出荷済みに変更するMutationの実装

### DIFF
--- a/GraphQL/Mutation/UpdateProductStockMutation.php
+++ b/GraphQL/Mutation/UpdateProductStockMutation.php
@@ -60,15 +60,15 @@ class UpdateProductStockMutation implements Mutation
             'args' => [
                 'code' => [
                     'type' => Type::nonNull(Type::string()),
-                    'description' => trans('api.args.description.product_code'),
+                    'description' => trans('api.update_product_stock.args.description.product_code'),
                 ],
                 'stock' => [
                     'type' => Type::int(),
-                    'description' => trans('api.args.description.stock'),
+                    'description' => trans('api.update_product_stock.args.description.stock'),
                 ],
                 'stock_unlimited' => [
                     'type' => Type::nonNull(Type::boolean()),
-                    'description' => trans('api.args.description.stock_unlimited'),
+                    'description' => trans('api.update_product_stock.args.description.stock_unlimited'),
                 ],
             ],
             'resolve' => [$this, 'updateProductStock'],

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -1,0 +1,299 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\GraphQL\Mutation;
+
+use Doctrine\ORM\EntityManager;
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Order;
+use Eccube\Entity\Shipping;
+use Eccube\Repository\Master\OrderStatusRepository;
+use Eccube\Repository\ShippingRepository;
+use Eccube\Service\MailService;
+use Eccube\Service\OrderStateMachine;
+use GraphQL\Type\Definition\Type;
+use Plugin\Api\GraphQL\Error\InvalidArgumentException;
+use Plugin\Api\GraphQL\Mutation;
+use Plugin\Api\GraphQL\Types;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class UpdateShippedMutation implements Mutation
+{
+    /**
+     * @var EccubeConfig
+     */
+    private $eccubeConfig;
+
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var MailService
+     */
+    private $mailService;
+
+    /**
+     * @var OrderStateMachine
+     */
+    private $orderStateMachine;
+
+    /**
+     * @var OrderStatusRepository
+     */
+    private $orderStatusRepository;
+
+    /**
+     * @var Types
+     */
+    private $types;
+
+    /**
+     * @var ShippingRepository
+     */
+    private $shippingRepository;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    public function __construct(
+        EccubeConfig $eccubeConfig,
+        EntityManager $entityManager,
+        MailService $mailService,
+        OrderStateMachine $orderStateMachine,
+        OrderStatusRepository $orderStatusRepository,
+        Types $types,
+        ShippingRepository $shippingRepository,
+        ValidatorInterface $validator
+    ) {
+        $this->types = $types;
+        $this->shippingRepository = $shippingRepository;
+        $this->orderStateMachine = $orderStateMachine;
+        $this->orderStatusRepository = $orderStatusRepository;
+        $this->mailService = $mailService;
+        $this->entityManager = $entityManager;
+        $this->validator = $validator;
+        $this->eccubeConfig = $eccubeConfig;
+    }
+
+    public function getName()
+    {
+        return 'updateShipped';
+    }
+
+    public function getMutation()
+    {
+        return  [
+            'type' => $this->types->get(Shipping::class),
+            'args' => [
+                'id' => [
+                    'type' => Type::nonNull(Type::id()),
+                    'description' => trans('api.update_shipped.args.description.id'),
+                ],
+                'shipping_date' => [
+                    'type' => Type::string(),
+                    'description' => trans('api.update_shipped.args.description.shipping_date'),
+                ],
+                'shipping_delivery_name' => [
+                    'type' => Type::string(),
+                    'description' => trans('api.update_shipped.args.description.shipping_delivery_name'),
+                ],
+                'tracking_number' => [
+                    'type' => Type::string(),
+                    'description' => trans('api.update_shipped.args.description.tracking_number'),
+                ],
+                'note' => [
+                    'type' => Type::string(),
+                    'description' => trans('api.update_shipped.args.description.note'),
+                ],
+                'is_send_mail' => [
+                    'type' => Type::boolean(),
+                    'defaultValue' => false,
+                    'description' => trans('api.update_shipped.args.description.is_send_mail'),
+                ],
+            ],
+            'resolve' => [$this, 'updateShipped'],
+        ];
+    }
+
+    public function updateShipped($root, $args)
+    {
+        // 引数の検証
+        $this->validateArgs($args);
+
+        /** @var Shipping $Shipping */
+        $Shipping = $this->shippingRepository->find($args['id']);
+
+        // 出荷処理が可能かの検証
+        $this->validateShippable($Shipping);
+
+        // args で Shipping の出荷済み処理
+        $this->updateShippingShippedWithArgs($Shipping, $args);
+
+        // Order の出荷済み処理
+        $this->updateOrderShipped($Shipping->getOrder());
+
+        // is_send_mail が true の場合は発送通知メールを送信する
+        if (array_key_exists('is_send_mail', $args) && $args['is_send_mail']) {
+            $this->sendShippingNotifyMail($Shipping);
+        }
+
+        $this->entityManager->flush();
+
+        return $Shipping;
+    }
+
+    /**
+     * 引数の検証
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateArgs(array $args): void
+    {
+        $constraint = $this->getConstraint();
+        $violations = $this->validator->validate($args, $constraint);
+
+        if (count($violations)) {
+            $message = '';
+            /** @var ConstraintViolationInterface $violation */
+            foreach ($violations as $violation) {
+                $message .= sprintf('%s: %s;', $violation->getPropertyPath(), $violation->getMessage());
+            }
+            throw new InvalidArgumentException($message);
+        }
+    }
+
+    private function getConstraint(): Constraint
+    {
+        return new Assert\Collection([
+            'fields' => [
+                'id' => new Assert\GreaterThan(0),
+                'shipping_date' => new Assert\DateTime(),
+                'shipping_delivery_name' => new Assert\Length([
+                    'max' => $this->eccubeConfig['eccube_mtext_len'],
+                ]),
+                'tracking_number' => new Assert\Length([
+                    'max' => $this->eccubeConfig['eccube_mtext_len'],
+                ]),
+                'note' => new Assert\Length([
+                    'max' => $this->eccubeConfig['eccube_ltext_len'],
+                ]),
+                'is_send_mail' => new Assert\Choice([true, false]),
+            ],
+            'allowMissingFields' => true,
+        ]);
+    }
+
+    /**
+     * 出荷処理が可能かの検証
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateShippable(Shipping $Shipping): void
+    {
+        // Shipping が存在しない場合
+        if (is_null($Shipping)) {
+            throw new InvalidArgumentException('id: No Shipping found;');
+        }
+
+        // Shipping がすでに出荷済みの場合
+        if ($Shipping->isShipped()) {
+            throw new InvalidArgumentException('id: Already shipped;');
+        }
+
+        /** @var OrderStatus $OrderStatus */
+        $OrderStatus = $this->orderStatusRepository->find(OrderStatus::DELIVERED);
+
+        // Order が出荷済みへ変更できない場合
+        if (!$this->orderStateMachine->can($Shipping->getOrder(), $OrderStatus)) {
+            throw new InvalidArgumentException('id: The associated order cannot be shipped;');
+        }
+    }
+
+    /**
+     * args で Shipping の出荷済み処理
+     *
+     * @param Shipping $Shipping
+     * @param array $args
+     * @throws InvalidArgumentException
+     */
+    private function updateShippingShippedWithArgs(Shipping $Shipping, array $args): void
+    {
+        // Shipping を出荷済みに変更
+        try {
+            $Shipping->setShippingDate(new \DateTime($args['shipping_date'] ?? 'now'));
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException('shipping_date: '.$e->getMessage());
+        }
+
+        // shipping_delivery_name が指定されている場合は配送社名を更新
+        if (array_key_exists('shipping_delivery_name', $args)) {
+            $Shipping->setShippingDeliveryName($args['shipping_delivery_name']);
+        }
+
+        // tracking_number が指定されている場合は配送番号を更新
+        if (array_key_exists('tracking_number', $args)) {
+            $Shipping->setTrackingNumber($args['tracking_number']);
+        }
+
+        // note が指定されている場合は出荷用メモ欄を更新
+        if (array_key_exists('note', $args)) {
+            $Shipping->setNote($args['note']);
+        }
+    }
+
+    /**
+     * Order の出荷済み処理
+     *
+     * @param Order $Order
+     */
+    private function updateOrderShipped(Order $Order): void
+    {
+        // Order に紐づく全ての Shipping が出荷済みか
+        $allShipped = array_reduce($Order->getShippings()->toArray(), function ($carry, $Shipping) {
+            return $carry && $Shipping->isShipped();
+        }, true);
+
+        /** @var OrderStatus $OrderStatus */
+        $OrderStatus = $this->orderStatusRepository->find(OrderStatus::DELIVERED);
+
+        // Shipping がすべて出荷済みなら Order を出荷済みに変更
+        if ($allShipped) {
+            $this->orderStateMachine->apply($Order, $OrderStatus);
+        }
+    }
+
+    /**
+     * 発送通知メールを送信する
+     *
+     * @param Shipping $Shipping
+     * @throws InvalidArgumentException
+     */
+    private function sendShippingNotifyMail(Shipping $Shipping): void
+    {
+        try {
+            $this->mailService->sendShippingNotifyMail($Shipping);
+            $Shipping->setMailSendDate(new \DateTime());
+        } catch (\Exception $e) {
+            // TODO: メールを送れなかったかといってすべてロールバックするのはおかしい気がするが、強制的に送信結果を返す手段がない
+            throw new InvalidArgumentException('is_send_mail: Error sending email;');
+        }
+    }
+}

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -230,11 +230,7 @@ class UpdateShippedMutation implements Mutation
     private function updateShippingShippedWithArgs(Shipping $Shipping, array $args): void
     {
         // Shipping を出荷済みに変更
-        try {
-            $Shipping->setShippingDate($args['shipping_date'] ?? new \DateTime());
-        } catch (\Exception $e) {
-            throw new InvalidArgumentException('shipping_date: '.$e->getMessage());
-        }
+        $Shipping->setShippingDate($args['shipping_date'] ?? new \DateTime());
 
         // shipping_delivery_name が指定されている場合は配送社名を更新
         if (array_key_exists('shipping_delivery_name', $args)) {

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -224,8 +224,6 @@ class UpdateShippedMutation implements Mutation
 
     /**
      * args で Shipping の出荷済み処理
-     *
-     * @throws InvalidArgumentException
      */
     private function updateShippingShippedWithArgs(Shipping $Shipping, array $args): void
     {

--- a/GraphQL/Query/SearchFormQuery.php
+++ b/GraphQL/Query/SearchFormQuery.php
@@ -86,7 +86,7 @@ abstract class SearchFormQuery implements Query
 
         // paging のためのフォームを追加
         $builder->add('page', IntegerType::class, [
-            'label' => 'api.args.description.page',
+            'label' => 'api.search_form_query.args.description.page',
             'required' => false,
             'data' => 1,
             'constraints' => [
@@ -96,7 +96,7 @@ abstract class SearchFormQuery implements Query
                 ]),
             ],
         ])->add('limit', IntegerType::class, [
-            'label' => 'api.args.description.limit',
+            'label' => 'api.search_form_query.args.description.limit',
             'required' => false,
             'data' => $this->eccubeConfig->get('eccube_default_page_count'),
             'constraints' => [

--- a/GraphQL/Type/Definition/DateTimeType.php
+++ b/GraphQL/Type/Definition/DateTimeType.php
@@ -20,6 +20,7 @@ use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
+use Plugin\Api\GraphQL\Error\InvalidArgumentException;
 
 class DateTimeType extends ScalarType
 {
@@ -53,10 +54,16 @@ class DateTimeType extends ScalarType
      * @param mixed $value
      *
      * @return DateTime|false|null
+     * @throws InvalidArgumentException
      */
     public function parseValue($value)
     {
-        return DateTime::createFromFormat(DateTime::ATOM, $value) ?: null;
+        $dateTime = DateTime::createFromFormat(DateTime::ATOM, $value);
+        if ($dateTime) {
+            return $dateTime;
+        } else {
+            throw new InvalidArgumentException('DateTime parse error, please specify in "Y-m-d\TH:i:sP".'.Utils::printSafe($value));
+        }
     }
 
     /**

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -40,13 +40,13 @@ api:
   update_product_stock:
     args:
       description:
-        product_code: SKU (required)
+        product_code: SKU
         stock: Stock (If the stock_unlimited is set to false, please set the value more than 0.)
         stock_unlimited: 'Stock unlimited (Specify false: Limited or true: Unlimited)'
   update_shipped:
     args:
       description:
-        id: Shipping ID (required)
+        id: Shipping ID
         shipping_date: Shipping Date (Specify like Y-m-d\TH:i:sP. Execution date if not specified.)
         shipping_delivery_name: Delivery Company Name
         tracking_number: Tracking No.

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -47,7 +47,7 @@ api:
     args:
       description:
         id: Shipping ID (required)
-        shipping_date: Shipping Date (Specify like Y-m-d H:i:s. Execution date if not specified.)
+        shipping_date: Shipping Date (Specify like Y-m-d\TH:i:sP. Execution date if not specified.)
         shipping_delivery_name: Delivery Company Name
         tracking_number: Tracking No.
         note: Notes

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -32,10 +32,23 @@ api:
   # API
   #------------------------------------------------------------------------------------
 
-  args:
-    description:
-      page: Page number
-      limit: Limit number per page
-      product_code: SKU
-      stock: If the stock_unlimited is set to false, please set the value more than 0.
-      stock_unlimited: 'Specify false: Limited or true: Unlimited'
+  search_form_query:
+    args:
+      description:
+        page: Page number
+        limit: Limit number per page
+  update_product_stock:
+    args:
+      description:
+        product_code: SKU (required)
+        stock: Stock (If the stock_unlimited is set to false, please set the value more than 0.)
+        stock_unlimited: 'Stock unlimited (Specify false: Limited or true: Unlimited)'
+  update_shipped:
+    args:
+      description:
+        id: Shipping ID (required)
+        shipping_date: Shipping Date (Specify like Y-m-d H:i:s. Execution date if not specified.)
+        shipping_delivery_name: Delivery Company Name
+        tracking_number: Tracking No.
+        note: Notes
+        is_send_mail: Shipment completion email send flag (specify true when sending)

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -47,7 +47,7 @@ api:
     args:
       description:
         id: 出荷ID（必須）
-        shipping_date: 出荷日（ Y-m-d H:i:s 形式で指定可能、未指定の場合は実行日時）
+        shipping_date: 出荷日（ Y-m-d\TH:i:sP 形式で指定可能、未指定の場合は実行日時）
         shipping_delivery_name: 出荷業者（変更する場合は必須）
         tracking_number: お問い合わせ番号（変更する場合は必須）
         note: 出荷用メモ欄（変更する場合は必須）

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -32,10 +32,23 @@ api:
   # API
   #------------------------------------------------------------------------------------
 
-  args:
-    description:
-      page: ページ番号
-      limit: ページあたりの取得数の上限
-      product_code: 商品コード
-      stock: stock_unlimited が false の場合、0以上の数値を設定してください。
-      stock_unlimited: 'false:制限, true: 無制限を指定します。'
+  search_form_query:
+    args:
+      description:
+        page: ページ番号
+        limit: ページあたりの取得数の上限
+  update_product_stock:
+    args:
+      description:
+        product_code: 商品コード（必須）
+        stock: 在庫数（在庫無制限の場合、0以上の数値を指定）
+        stock_unlimited: 在庫無制限（無制限は true 、制限は false を指定）
+  update_shipped:
+    args:
+      description:
+        id: 出荷ID（必須）
+        shipping_date: 出荷日（ Y-m-d H:i:s 形式で指定可能、未指定の場合は実行日時）
+        shipping_delivery_name: 出荷業者（変更する場合は必須）
+        tracking_number: お問い合わせ番号（変更する場合は必須）
+        note: 出荷用メモ欄（変更する場合は必須）
+        is_send_mail: 出荷完了メール送信フラグ（送信する場合は true を指定）

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -40,15 +40,15 @@ api:
   update_product_stock:
     args:
       description:
-        product_code: 商品コード（必須）
+        product_code: 商品コード
         stock: 在庫数（在庫無制限の場合、0以上の数値を指定）
         stock_unlimited: 在庫無制限（無制限は true 、制限は false を指定）
   update_shipped:
     args:
       description:
-        id: 出荷ID（必須）
+        id: 出荷ID
         shipping_date: 出荷日（ Y-m-d\TH:i:sP 形式で指定可能、未指定の場合は実行日時）
-        shipping_delivery_name: 出荷業者（変更する場合は必須）
-        tracking_number: お問い合わせ番号（変更する場合は必須）
-        note: 出荷用メモ欄（変更する場合は必須）
+        shipping_delivery_name: 出荷業者
+        tracking_number: お問い合わせ番号
+        note: 出荷用メモ欄
         is_send_mail: 出荷完了メール送信フラグ（送信する場合は true を指定）

--- a/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
@@ -127,10 +127,13 @@ class UpdateShippedMutationTest extends EccubeTestCase
 
     public function validateArgsProvider()
     {
-        $str_eccube_mtext_len = str_repeat('a', $this->eccubeConfig['eccube_mtext_len']);
-        $str_eccube_mtext_len_plus = str_repeat('a', $this->eccubeConfig['eccube_mtext_len'] + 1);
-        $str_eccube_ltext_len = str_repeat('a', $this->eccubeConfig['eccube_ltext_len']);
-        $str_eccube_ltext_len_plus = str_repeat('a', $this->eccubeConfig['eccube_ltext_len'] + 1);
+        // dataProvider 実行時点で eccubeConfig がまだ使えないのでベタがきする。
+        $eccube_mtext_len = 200;
+        $eccube_ltext_len = 3000;
+        $str_eccube_mtext_len = str_repeat('a', $eccube_mtext_len);
+        $str_eccube_mtext_len_plus = str_repeat('a', $eccube_mtext_len + 1);
+        $str_eccube_ltext_len = str_repeat('a', $eccube_ltext_len);
+        $str_eccube_ltext_len_plus = str_repeat('a', $eccube_ltext_len + 1);
 
         $dateTime = DateTime::createFromFormat(DateTime::ATOM, '2020-05-18T12:57:08+09:00');
 
@@ -138,7 +141,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
             [['id' => -1], '/id/'],
             [['shipping_date' => $dateTime]],
             [['shipping_delivery_name' => $str_eccube_mtext_len]],
-            [['shipping_delivery_name' => $str_eccube_mtext_len_plus], '/shipping_date/'],
+            [['shipping_delivery_name' => $str_eccube_mtext_len_plus], '/shipping_delivery_name/'],
             [['tracking_number' => $str_eccube_mtext_len]],
             [['tracking_number' => $str_eccube_mtext_len_plus], '/tracking_number/'],
             [['note' => $str_eccube_ltext_len]],

--- a/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api\Tests\GraphQL\Mutation;
+
+use Eccube\Entity\Master\OrderStatus;
+use Eccube\Entity\Order;
+use Eccube\Entity\Shipping;
+use Eccube\Repository\Master\OrderStatusRepository;
+use Eccube\Repository\ShippingRepository;
+use Eccube\Service\MailService;
+use Eccube\Service\OrderStateMachine;
+use Eccube\Tests\EccubeTestCase;
+use Plugin\Api\GraphQL\Error\InvalidArgumentException;
+use Plugin\Api\GraphQL\Mutation\UpdateShippedMutation;
+use Plugin\Api\GraphQL\Types;
+
+class UpdateShippedMutationTest extends EccubeTestCase
+{
+    /**
+     * @var UpdateShippedMutation
+     */
+    private $updateShippedMutation;
+
+    /**
+     * @var Order
+     */
+    private $Order;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $mailService = $this->container->get(MailService::class);
+        $orderStateMachine = $this->container->get(OrderStateMachine::class);
+        $orderStatusRepository = $this->container->get(OrderStatusRepository::class);
+        $types = $this->container->get(Types::class);
+        $shippingRepository = $this->container->get(ShippingRepository::class);
+
+        $this->updateShippedMutation = new UpdateShippedMutation(
+            $this->eccubeConfig,
+            $this->entityManager,
+            $mailService,
+            $orderStateMachine,
+            $orderStatusRepository,
+            $types,
+            $shippingRepository
+        );
+
+        // 出荷可能な受注を作成
+        $Customer = $this->createCustomer();
+        $this->Order = $this->createOrder($Customer);
+        $OrderStatus = $this->entityManager->getRepository(OrderStatus::class)->find(OrderStatus::NEW);
+        $this->Order->setOrderStatus($OrderStatus);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * 正常系
+     */
+    public function testResponseAndDB()
+    {
+        $args = [
+            'id' => $this->Order->getShippings()->current()->getId(),
+            'shipping_date' => '2020-05-18 12:00:00',
+            'shipping_delivery_name' => 'テスト配送業者',
+            'tracking_number' => 'tracking_number_0123',
+            'note' => 'notes_0123456789',
+//            'is_send_mail' => true, // TODO: メール送信でエラーとなるためスキップ
+        ];
+
+        try {
+            $Shipping = $this->updateShippedMutation->updateShipped(null, $args);
+
+            // レスポンスの確認
+            $Shipping->getShippingDate()->setTimezone(new \DateTimeZone($this->eccubeConfig['timezone']));
+            self::assertEquals('2020-05-18 12:00:00', $Shipping->getShippingDate()->format('Y-m-d H:i:s'));
+            self::assertEquals('テスト配送業者', $Shipping->getShippingDeliveryName());
+            self::assertEquals('tracking_number_0123', $Shipping->getTrackingNumber());
+            self::assertEquals('notes_0123456789', $Shipping->getNote());
+        } catch (InvalidArgumentException $e) {
+            // 通らない
+            self::assertTrue(false);
+        }
+
+        // DB の確認
+        $this->entityManager->refresh($this->Order);
+        $this->Order->getShippings()->current()->getShippingDate()->setTimezone(new \DateTimeZone($this->eccubeConfig['timezone']));
+        self::assertEquals('2020-05-18 12:00:00', $this->Order->getShippings()->current()->getShippingDate()->format('Y-m-d H:i:s'));
+        self::assertEquals('テスト配送業者', $this->Order->getShippings()->current()->getShippingDeliveryName());
+        self::assertEquals('tracking_number_0123', $this->Order->getShippings()->current()->getTrackingNumber());
+        self::assertEquals('notes_0123456789', $this->Order->getShippings()->current()->getNote());
+    }
+
+    /**
+     * 引数のバリデーションチェック
+     *
+     * @dataProvider validateArgsProvider
+     */
+    public function testValidateArgs(array $args, string $message = null)
+    {
+        $args = array_merge($args, ['id' => $this->Order->getShippings()->current()->getId()]);
+
+        try {
+            $Shipping = $this->updateShippedMutation->updateShipped(null, $args);
+            // Shipping が出荷済みになっている
+            self::assertNotNull($Shipping->getShippingDate());
+            self::assertNotNull($this->Order->getShippings()->current()->getShippingDate());
+        } catch (InvalidArgumentException $e) {
+            // エラーの確認
+            self::assertEquals('Invalid argument', $e->getCategory());
+            self::assertRegExp($message, $e->getMessage());
+            // Shipping が出荷済みになっていない
+            self::assertNull($this->Order->getShippings()->current()->getShippingDate());
+        }
+    }
+
+    public function validateArgsProvider()
+    {
+        $str_eccube_mtext_len = str_repeat('a', $this->eccubeConfig['eccube_mtext_len']);
+        $str_eccube_mtext_len_plus = str_repeat('a', $this->eccubeConfig['eccube_mtext_len'] + 1);
+        $str_eccube_ltext_len = str_repeat('a', $this->eccubeConfig['eccube_ltext_len']);
+        $str_eccube_ltext_len_plus = str_repeat('a', $this->eccubeConfig['eccube_ltext_len'] + 1);
+
+        return [
+            [['id' => -1], '/id/'],
+            [['shipping_date' => '2020-05-18 09:00:00']],
+            [['shipping_date' => '2020-05-18 09:00:00aaaa'], '/shipping_date/'],
+            [['shipping_delivery_name' => $str_eccube_mtext_len]],
+            [['shipping_delivery_name' => $str_eccube_mtext_len_plus], '/shipping_date/'],
+            [['tracking_number' => $str_eccube_mtext_len]],
+            [['tracking_number' => $str_eccube_mtext_len_plus], '/tracking_number/'],
+            [['note' => $str_eccube_ltext_len]],
+            [['note' => $str_eccube_ltext_len_plus], '/note/'],
+//            [['is_send_mail' => true]], // TODO: メール送信でエラーとなるためスキップ
+            [['is_send_mail' => false]],
+        ];
+    }
+
+    /**
+     * 対象の出荷情報がない場合
+     */
+    public function testNoShippingFound()
+    {
+        $args = ['id' => 9999];
+
+        try {
+            $this->updateShippedMutation->updateShipped(null, $args);
+            // 通らない
+            self::assertTrue(false);
+        } catch (InvalidArgumentException $e) {
+            // エラーの確認
+            self::assertEquals('Invalid argument', $e->getCategory());
+            self::assertRegExp('/No Shipping found/', $e->getMessage());
+        }
+    }
+
+    /**
+     * 対象の出荷情報がすでに出荷済みの場合
+     */
+    public function testAlreadyShipped()
+    {
+        // Shipping を出荷済みに変更
+        /** @var Shipping $Shipping */
+        $Shipping = $this->Order->getShippings()->current();
+        $Shipping->setShippingDate(new \DateTime());
+        $this->entityManager->flush();
+
+        $args = ['id' => $Shipping->getId()];
+
+        try {
+            $this->updateShippedMutation->updateShipped(null, $args);
+            // 通らない
+            self::assertTrue(false);
+        } catch (InvalidArgumentException $e) {
+            // エラーの確認
+            self::assertEquals('Invalid argument', $e->getCategory());
+            self::assertRegExp('/Already shipped/', $e->getMessage());
+        }
+    }
+
+    /**
+     * 対象の受注情報が出荷済みにできない受注ステータスだった場合
+     */
+    public function testOrderCannotBeShipped()
+    {
+        // 受注をキャンセルに変更
+        $OrderStatus = $this->entityManager->getRepository(OrderStatus::class)->find(OrderStatus::CANCEL);
+        $this->Order->setOrderStatus($OrderStatus);
+        $this->entityManager->flush();
+
+        $args = ['id' => $this->Order->getShippings()->current()->getId()];
+
+        try {
+            $this->updateShippedMutation->updateShipped(null, $args);
+            // 通らない
+            self::assertTrue(false);
+        } catch (InvalidArgumentException $e) {
+            // エラーの確認
+            self::assertEquals('Invalid argument', $e->getCategory());
+            self::assertRegExp('/order cannot be shipped/', $e->getMessage());
+        }
+    }
+
+    /**
+     * 対象の受注の出荷情報が全て出荷済みになれば受注を出荷済みにする
+     */
+    public function testOrderShipped()
+    {
+        // Orderを新しく作り、Shippingをもう一方に付け替える
+        $Order = $this->createOrder($this->Order->getCustomer());
+        /** @var Shipping $Shipping */
+        $Shipping = $Order->getShippings()->current();
+        $Shipping->setOrder($this->Order);
+        $Order->removeShipping($Shipping);
+        $this->Order->addShipping($Shipping);
+        $this->entityManager->flush();
+
+        // １個目の出荷情報を出荷済みに変更
+        $args = ['id' => $this->Order->getShippings()[0]->getId()];
+
+        try {
+            $Shipping = $this->updateShippedMutation->updateShipped(null, $args);
+            // Shipping が出荷済みになっている
+            self::assertNotNull($Shipping->getShippingDate());
+            self::assertNotNull($this->Order->getShippings()[0]->getShippingDate());
+            // 受注は出荷済みになっていない
+            $OrderStatus = $this->entityManager->getRepository(OrderStatus::class)->find(OrderStatus::NEW);
+            self::assertEquals($OrderStatus, $this->Order->getOrderStatus());
+        } catch (InvalidArgumentException $e) {
+            // 通らない
+            self::assertTrue(false);
+        }
+
+        // ２個目の出荷情報を出荷済みに変更
+        $args = ['id' => $this->Order->getShippings()[1]->getId()];
+
+        try {
+            $Shipping = $this->updateShippedMutation->updateShipped(null, $args);
+            // Shipping が出荷済みになっている
+            self::assertNotNull($Shipping->getShippingDate());
+            self::assertNotNull($this->Order->getShippings()[1]->getShippingDate());
+            // 受注も出荷済みになっている
+            $OrderStatus = $this->entityManager->getRepository(OrderStatus::class)->find(OrderStatus::DELIVERED);
+            self::assertEquals($OrderStatus, $this->Order->getOrderStatus());
+        } catch (InvalidArgumentException $e) {
+            // 通らない
+            self::assertTrue(false);
+        }
+    }
+}


### PR DESCRIPTION
close #39 

リクエスト例

```graphql
mutation UpdateShipped(
    $id: ID!,
    $shipping_date: DateTime,
    $shipping_delivery_name: String,
    $tracking_number: String,
    $note: String,
    $is_send_mail: Boolean
  ){
  updateShipped (
    id: $id,
    shipping_date: $shipping_date
    shipping_delivery_name: $shipping_delivery_name
    tracking_number: $tracking_number
    note: $note
    is_send_mail: $is_send_mail
  ) {
    id
    shipping_delivery_name
    shipping_delivery_date
    shipping_date
    tracking_number
    note
    mail_send_date
    Order {
      OrderStatus {
        id
        name
      }
    }
  }
}
```

variables
```json
{
  "id": 1576,
  "shipping_date": "2020-05-18T12:57:08+09:00",
  "shipping_delivery_name": "オレオレ配送業者",
  "tracking_number": "tracking_number0123",
  "note": "Hello Notes!",
  "is_send_mail": true
}
```

レスポンス

```json
{
  "data": {
    "updateShipped": {
      "id": "1576",
      "shipping_delivery_name": "オレオレ配送業者",
      "shipping_delivery_date": null,
      "shipping_date": "2020-05-18T00:00:00+00:00",
      "tracking_number": "tracking_number0123",
      "note": "Hello Notes!",
      "mail_send_date": "2020-07-29T08:58:08+00:00",
      "Order": {
        "OrderStatus": {
          "id": "5",
          "name": "発送済み"
        }
      }
    }
  }
}
```