### PR TITLE
デフォルトの鍵保管場所を変更

### DIFF
--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,6 +1,6 @@
 parameters:
-    env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY): '%kernel.project_dir%/var/oauth/private.key'
-    env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY): '%kernel.project_dir%/var/oauth/public.key'
+    env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY): '%kernel.project_dir%/app/PluginData/Api/oauth/private.key'
+    env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY): '%kernel.project_dir%/app/PluginData/Api/oauth/public.key'
     env(ECCUBE_OAUTH2_ENCRYPTION_KEY): '<change.me>'
 
 trikoder_oauth2:


### PR DESCRIPTION
[EC-CUBEのディレクトリ構成](https://doc4.ec-cube.net/plugin_spec#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB)に従って `app/PluginData` 以下にしました。