### PR TITLE
OAuth管理画面の改善

### DIFF
--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -30,6 +30,7 @@ use Trikoder\Bundle\OAuth2Bundle\Model\Client;
 use Trikoder\Bundle\OAuth2Bundle\Model\Grant;
 use Trikoder\Bundle\OAuth2Bundle\Model\RedirectUri;
 use Trikoder\Bundle\OAuth2Bundle\Model\Scope;
+use Trikoder\Bundle\OAuth2Bundle\OAuth2Grants;
 
 class OAuthController extends AbstractController
 {
@@ -212,6 +213,10 @@ class OAuthController extends AbstractController
             },
             $form->get('grants')->getData()
         );
+        // authorization code grant が選択されていた場合には refresh token grant も付与
+        if (in_array(OAuth2Grants::AUTHORIZATION_CODE, $grants)) {
+            array_push($grants, new Grant(OAuth2Grants::REFRESH_TOKEN));
+        }
         $client->setGrants(...$grants);
 
         $scopes = array_map(

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -210,7 +210,7 @@ class OAuthController extends AbstractController
             function (string $grant): Grant {
                 return new Grant($grant);
             },
-            explode(',', $form->get('grants')->getData())
+            $form->get('grants')->getData()
         );
         $client->setGrants(...$grants);
 
@@ -218,7 +218,7 @@ class OAuthController extends AbstractController
             function (string $scope): Scope {
                 return new Scope($scope);
             },
-            explode(',', $form->get('scopes')->getData())
+            $form->get('scopes')->getData()
         );
         $client->setScopes(...$scopes);
 

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -16,6 +16,7 @@ namespace Plugin\Api\Form\Type\Admin;
 use Eccube\Common\EccubeConfig;
 use Exception;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -64,12 +65,16 @@ class ClientType extends AbstractType
                     new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
                 ],
             ])
-            ->add('scopes', TextType::class, [
+            ->add('scopes', ChoiceType::class, [
+                'choices'  => [
+                    'read' => 'read',
+                    'write' => 'write',
+                ],
+                'expanded' => true,
+                'multiple' => true,
                 'mapped' => false,
-                'data' => 'read',
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
                 ],
             ])
             ->add('redirect_uris', TextType::class, [
@@ -80,12 +85,16 @@ class ClientType extends AbstractType
                     new Assert\Url(),
                 ],
             ])
-            ->add('grants', TextType::class, [
+            ->add('grants', ChoiceType::class, [
+                'choices'  => [
+                    'authorization_code' => 'authorization_code',
+                    'refresh_token' => 'refresh_token',
+                ],
+                'expanded' => true,
+                'multiple' => true,
                 'mapped' => false,
-                'data' => 'authorization_code,refresh_token',
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
                 ],
             ]);
     }

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+use Trikoder\Bundle\OAuth2Bundle\OAuth2Grants;
 
 class ClientType extends AbstractType
 {
@@ -87,11 +88,11 @@ class ClientType extends AbstractType
             ])
             ->add('grants', ChoiceType::class, [
                 'choices'  => [
-                    'authorization_code' => 'authorization_code',
-                    'refresh_token' => 'refresh_token',
+                    'Authorization code' => OAuth2Grants::AUTHORIZATION_CODE,
                 ],
                 'expanded' => true,
                 'multiple' => true,
+                'data' => [OAuth2Grants::AUTHORIZATION_CODE],
                 'mapped' => false,
                 'constraints' => [
                     new Assert\NotBlank(),

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -22,6 +22,8 @@ api:
       delete__confirm_title: Delete a Client
       delete__confirm_message: Are you sure to delete this Client?
       clear_expired_tokens: Clears all expired access and/or refresh tokens
+      copy: Copy
+      copied: Copied
     webhook:
       management:  WebHook
       registration: WebHook Registration

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -9,10 +9,15 @@ api:
     oauth:
       management: OAuth
       identifier: Client ID
+      identifier_tooltip: Up to 32 alphanumeric characters
       secret: Client Secret
+      secret_tooltip: Up to 128 alphanumeric characters
       scope: Scope
+      scope_tooltip: GraphQL Query requires read, Mutation requires write/write Scope
       redirect_uri: Redirect URI
+      redirect_uri_tooltip: You can enter multiple URIs separated by commas
       grant_type: Grant Type
+      grant_type_tooltip: Supports only authorization code grant
       client_registration: Client Registration
       delete__confirm_title: Delete a Client
       delete__confirm_message: Are you sure to delete this Client?

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -9,10 +9,15 @@ api:
     oauth:
       management: OAuth管理
       identifier: クライアントID
+      identifier_tooltip: 32文字以下の半角英数
       secret: クライアントシークレット
+      secret_tooltip: 128文字以下の半角英数
       scope: スコープ
+      scope_tooltip: GraphQLのQueryにはread, Mutationにはwrite/writeのScopeが必要
       redirect_uri: リダイレクトURI
+      redirect_uri_tooltip: カンマ区切りで複数のURIを入力可能
       grant_type: グラントタイプ
+      grant_type_tooltip: Authorization code grantのみサポート
       client_registration: OAuthクライアント登録
       delete__confirm_title: OAuthクライアントを削除します。
       delete__confirm_message: OAuthクライアントを削除してよろしいですか？

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -22,6 +22,8 @@ api:
       delete__confirm_title: OAuthクライアントを削除します。
       delete__confirm_message: OAuthクライアントを削除してよろしいですか？
       clear_expired_tokens: 期限切れのアクセストークンとリフレッシュトークンを削除する
+      copy: コピーする
+      copied: コピーしました
     webhook:
       management:  WebHook管理
       registration: WebHook登録

--- a/Resource/template/admin/OAuth/edit.twig
+++ b/Resource/template/admin/OAuth/edit.twig
@@ -37,8 +37,13 @@ file that was distributed with this source code.
                                 {# identifier #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <span>{{ 'api.admin.oauth.identifier'|trans }}</span>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.identifier_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.identifier'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ml-1"></i>
+                                            <span class="badge badge-primary ml-1">
+                                                {{ 'admin.common.required'|trans }}
+                                            </span>
+                                        </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
@@ -53,8 +58,13 @@ file that was distributed with this source code.
                                 {# secret #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <span>{{ 'api.admin.oauth.secret'|trans }}</span>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.secret_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.secret'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ml-1"></i>
+                                            <span class="badge badge-primary ml-1">
+                                                {{ 'admin.common.required'|trans }}
+                                            </span>
+                                        </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
@@ -69,15 +79,20 @@ file that was distributed with this source code.
                                 {# scope #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <span>{{ 'api.admin.oauth.scope'|trans }}</span>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.scope_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.scope'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ml-1"></i>
+                                            <span class="badge badge-primary ml-1">
+                                                {{ 'admin.common.required'|trans }}
+                                            </span>
+                                        </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.scopes, {'attr': { 'readonly': 'readonly' } }) }}
+                                                {{ form_widget(form.scopes, {'label_attr': {'class': 'checkbox-inline'}}) }}
                                             </div>
-                                            {{ form_errors(form.scopes) }}
+                                            {{ form_errors(form.scopes, {'label_attr': {'class': 'checkbox-inline'}}) }}
                                         </div>
                                     </div>
                                 </div>
@@ -85,8 +100,13 @@ file that was distributed with this source code.
                                 {# redirect_uri #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <span>{{ 'api.admin.oauth.redirect_uri'|trans }}</span>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.redirect_uri_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.redirect_uri'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ml-1"></i>
+                                            <span class="badge badge-primary ml-1">
+                                                {{ 'admin.common.required'|trans }}
+                                            </span>
+                                        </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
@@ -101,15 +121,20 @@ file that was distributed with this source code.
                                 {# grant_type #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <span>{{ 'api.admin.oauth.grant_type'|trans }}</span>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.grant_type_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.grant_type'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ml-1"></i>
+                                            <span class="badge badge-primary ml-1">
+                                                {{ 'admin.common.required'|trans }}
+                                            </span>
+                                        </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
                                             <div class="col">
-                                                {{ form_widget(form.grants, {'attr': { 'readonly': 'readonly' } }) }}
+                                                {{ form_widget(form.grants, {'label_attr': {'class': 'checkbox-inline'}}) }}
                                             </div>
-                                            {{ form_errors(form.grants) }}
+                                            {{ form_errors(form.grants, {'label_attr': {'class': 'checkbox-inline'}}) }}
                                         </div>
                                     </div>
                                 </div>

--- a/Resource/template/admin/OAuth/index.twig
+++ b/Resource/template/admin/OAuth/index.twig
@@ -15,6 +15,29 @@ file that was distributed with this source code.
 {% block title %}{{ 'api.admin.oauth.management'|trans }}{% endblock %}
 {% block sub_title %}{{ 'api.admin.management'|trans }}{% endblock %}
 
+{% block javascript %}
+    <script>
+        $(function() {
+            $('.copy-secret').focus(function(){
+                $(this).select();
+                if (document.execCommand('copy')) {
+                    var action_copy = $(this);
+                    setTimeout(function() {
+                        action_copy.attr('title', '{{ 'api.admin.oauth.copied'|trans }}');
+                        action_copy.tooltip('_fixTitle');
+                        action_copy.tooltip('show');
+                     }, 100);
+                    setTimeout(function() {
+                        action_copy.attr('title', '{{ 'api.admin.oauth.copy'|trans }}');
+                        action_copy.tooltip('_fixTitle');
+                        action_copy.tooltip('hide');
+                     }, 3000);
+                }
+            });
+        });
+    </script>
+{% endblock javascript %}
+
 {% block main %}
     <div class="c-contentsArea__cols">
         <div class="c-contentsArea__primaryCol">
@@ -27,10 +50,10 @@ file that was distributed with this source code.
                         <table class="table table-sm" style="table-layout:fixed;">
                             <thead>
                             <tr>
-                                <th class="border-top-0 pt-2 pb-2 text-center" style="width:300px;">
+                                <th class="border-top-0 pt-2 pb-2 text-center">
                                     {{ 'api.admin.oauth.identifier'|trans }}
                                 </th>
-                                <th class="border-top-0 pt-2 pb-2 text-center" style="width:400px;">
+                                <th class="border-top-0 pt-2 pb-2 text-center">
                                     {{ 'api.admin.oauth.secret'|trans }}
                                 </th>
                                 <th class="border-top-0 pt-2 pb-2 text-center">
@@ -49,10 +72,10 @@ file that was distributed with this source code.
                             {% for client in clients %}
                                 <tr id="client-{{ client.identifier }}">
                                     <td class="align-middle text-center pl-3">
-                                        {{ client.identifier }}
+                                        <input type="text" class="form-control copy-secret" value="{{ client.identifier }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
                                     </td>
                                     <td class="align-middle text-center">
-                                        {{ client.Secret }}
+                                        <input type="text" class="form-control copy-secret" value="{{ client.Secret }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
                                     </td>
                                     <td class="align-middle text-center pl-3">
                                         {% for Scope in client.scopes %}

--- a/Resource/template/admin/OAuth/index.twig
+++ b/Resource/template/admin/OAuth/index.twig
@@ -78,18 +78,18 @@ file that was distributed with this source code.
                                         <input type="text" class="form-control copy-secret" value="{{ client.Secret }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
                                     </td>
                                     <td class="align-middle text-center pl-3">
-                                        {% for Scope in client.scopes %}
-                                            {{ Scope }}<br>
+                                        {% for scope in client.scopes %}
+                                            {{ scope }}<br>
                                         {% endfor %}
                                     </td>
                                     <td class="align-middle text-center">
-                                        {% for RedirectUri in client.redirectUris %}
-                                            {{ RedirectUri }}<br>
+                                        {% for redirectUri in client.redirectUris %}
+                                            {{ redirectUri }}<br>
                                         {% endfor %}
                                     </td>
                                     <td class="align-middle text-center pl-3">
-                                        {% for Grant in client.grants %}
-                                            {{ Grant }}<br>
+                                        {% for grant in client.grants if grant != 'refresh_token' %}
+                                            {{ grant }}<br>
                                         {% endfor %}
                                     </td>
                                     <td class="align-middle pr-3">

--- a/Tests/Web/Admin/OAuthControllerTest.php
+++ b/Tests/Web/Admin/OAuthControllerTest.php
@@ -16,6 +16,7 @@ namespace Plugin\Api\Tests\Web\Admin;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use Trikoder\Bundle\OAuth2Bundle\Manager\Doctrine\ClientManager;
 use Trikoder\Bundle\OAuth2Bundle\Model\Client;
+use Trikoder\Bundle\OAuth2Bundle\OAuth2Grants;
 
 class OAuthControllerTest extends AbstractAdminWebTestCase
 {
@@ -88,6 +89,15 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->expected = $formData['identifier'];
         $this->verify();
 
+        $scopes = $client->getScopes();
+        $this->assertTrue(in_array('read', $scopes));
+        $this->assertTrue(in_array('write', $scopes));
+
+        // authorization code grant が選択されていた場合には refresh token grant も付与される
+        $grants = $client->getGrants();
+        $this->assertTrue(in_array(OAuth2Grants::AUTHORIZATION_CODE, $grants));
+        $this->assertTrue(in_array(OAuth2Grants::REFRESH_TOKEN, $grants));
+
         $crawler = $this->client->followRedirect();
         $this->assertRegExp('/保存しました/u', $crawler->filter('div.alert-success')->text());
     }
@@ -134,9 +144,9 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
             '_token' => 'dummy',
             'identifier' => hash('md5', random_bytes(16)),
             'secret' => hash('sha512', random_bytes(32)),
-            'scopes' => 'read',
+            'scopes' => ['read', 'write'],
             'redirect_uris' => 'http://127.0.0.1:8000/',
-            'grants' => 'authorization_code',
+            'grants' => ['authorization_code'],
         ];
     }
 }


### PR DESCRIPTION
OAuth管理画面を改善しました。

- クライアントを登録時にScopeとGrantを選択できるようにしました。 close #62
- 各項目にツールチップを設定しました。
- 一覧画面でIDとSecretをコピーできるようにしました。 close #61

![image](https://user-images.githubusercontent.com/16895409/89244324-27f7f000-d641-11ea-95f2-569e6e7f5718.png)

![image](https://user-images.githubusercontent.com/16895409/89244368-4100a100-d641-11ea-83a2-1de7c9d452fc.png)

Secretを全く非表示にするのは大変だったので、妥協しています。（フォームを非表示にするとコピーできない）