### PR TITLE
DateTime型のargsを型変換するように修正

### DIFF
--- a/GraphQL/Query/SearchFormQuery.php
+++ b/GraphQL/Query/SearchFormQuery.php
@@ -124,6 +124,17 @@ abstract class SearchFormQuery implements Query
             'args' => $args,
             'resolve' => function ($root, $args) use ($builder, $resolver) {
                 $form = $builder->getForm();
+
+                foreach ($form->all() as $field) {
+                    $formConfig = $field->getConfig();
+                    if ($formConfig->getType()->getInnerType() instanceof DateTimeType) {
+                        $value = $args[$field->getName()];
+                        if ($value instanceof \DateTime) {
+                            $args[$field->getName()] = $value->format(\DateTime::ATOM);
+                        }
+                    }
+                }
+
                 $form->submit($args);
 
                 if (!$form->isValid()) {

--- a/GraphQL/Type/Definition/DateTimeType.php
+++ b/GraphQL/Type/Definition/DateTimeType.php
@@ -75,7 +75,7 @@ class DateTimeType extends ScalarType
     public function parseLiteral($valueNode, ?array $variables = null)
     {
         if ($valueNode instanceof StringValueNode) {
-            return $valueNode->value;
+            return $this->parseValue($valueNode->value);
         }
 
         return null;


### PR DESCRIPTION
- `Plugin\Api\GraphQL\Type\Definition\DateTimeType#parseLiteral` で DateTime型を返すように修正。
- FormTypeを使った場合は、string -> DateTIme -> string -> DateTime と2回変換が行われてしまうが、仕方ない。

ref #77