### PR TITLE
doc4.ec-cube.net のテーマに合わせる

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@
 # https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/#installing-the-theme
 
 # theme                  : "minimal-mistakes-jekyll"
-# remote_theme           : "mmistakes/minimal-mistakes"
+remote_theme             : "mmistakes/minimal-mistakes@4.20.1"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings
@@ -273,9 +273,11 @@ defaults:
       type: pages
     values:
       layout: single
-      author_profile: true
+      author_profile: false
       read_time: true
-      comments: # true
-      share: true
-      related: true
+      comments: false
+      share: false
+      related: false
+      toc: true
+      toc_sticky: true
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links
 main:
-  - title: "Quick-Start Guide"
-    url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
+  # - title: "Quick-Start Guide"
+  #   url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
   # - title: "About"
   #   url: https://mmistakes.github.io/minimal-mistakes/about/
   # - title: "Sample Posts"

--- a/docs/_pages/authZ_code_grant.md
+++ b/docs/_pages/authZ_code_grant.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /authZ_code_grant
 ---
 ## Authorization Code Flow での認可

--- a/docs/_pages/customize/allow_list.md
+++ b/docs/_pages/customize/allow_list.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /customize/allow_list
 ---
 

--- a/docs/_pages/customize/query.md
+++ b/docs/_pages/customize/query.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /customize/query
 ---
 

--- a/docs/_pages/index.md
+++ b/docs/_pages/index.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /
 ---
 EC-CUBE4 対応の Web API プラグイン

--- a/docs/_pages/mutation/product_stock.md
+++ b/docs/_pages/mutation/product_stock.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /mutation/product_stock
 ---
 

--- a/docs/_pages/mutation/update_shipped.md
+++ b/docs/_pages/mutation/update_shipped.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /mutation/update_shipped
 ---
 

--- a/docs/_pages/query/customers.md
+++ b/docs/_pages/query/customers.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /query/customers
 ---
 ## 顧客一覧の取得

--- a/docs/_pages/query/orders.md
+++ b/docs/_pages/query/orders.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /query/orders
 ---
 ## 受注一覧の取得

--- a/docs/_pages/query/products.md
+++ b/docs/_pages/query/products.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /query/products
 ---
 ## 商品一覧の取得

--- a/docs/_pages/schema.md
+++ b/docs/_pages/schema.md
@@ -1,6 +1,4 @@
 ---
-layout: home
-author_profile: true
 permalink: /schema
 ---
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -1,0 +1,16 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
+@import "minimal-mistakes"; // main partials
+
+.page {
+  @extend .page;
+  width: 100%;
+}
+.page__footer-follow {
+  display: none;
+}


### PR DESCRIPTION
- doc4.ec-cube.net  と同じテーマを remote_theme に設定しました
- 目次をつけて見やすくする
- YAML front matter を最小限に

<img width="1434" alt="スクリーンショット 2020-08-07 11 53 07" src="https://user-images.githubusercontent.com/815715/89616923-30139200-d8c4-11ea-939a-b6d01de85db1.png">