### PR TITLE
エンドポイントをコピーできる機能の追加

### DIFF
--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -7,6 +7,10 @@ api:
   admin:
     management: API
     oauth:
+      endpoint: Endpoint
+      authorization_endpoint: Authorization endpoint
+      token_endpoint: Token endpoint
+      api_endpoint: API endpoint
       management: OAuth
       identifier: Client ID
       identifier_tooltip: Up to 32 alphanumeric characters

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -7,6 +7,10 @@ api:
   admin:
     management: API管理
     oauth:
+      endpoint: Endpoint
+      authorization_endpoint: Authorization endpoint
+      token_endpoint: Token endpoint
+      api_endpoint: API endpoint
       management: OAuth管理
       identifier: クライアントID
       identifier_tooltip: 32文字以下の半角英数

--- a/Resource/template/admin/OAuth/index.twig
+++ b/Resource/template/admin/OAuth/index.twig
@@ -42,6 +42,41 @@ file that was distributed with this source code.
     <div class="c-contentsArea__cols">
         <div class="c-contentsArea__primaryCol">
             <div class="c-primaryCol">
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-header"><span>{{ 'api.admin.oauth.endpoint'|trans }}</span></div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-3">
+                                <div class="d-inline-block">
+                                    <span>{{ 'api.admin.oauth.authorization_endpoint'|trans }}</span>
+                                </div>
+                            </div>
+                            <div class="col mb-2">
+                                <input type="text" class="form-control copy-secret" value="{{ url('oauth2_authorize') }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-3">
+                                <div class="d-inline-block">
+                                    <span>{{ 'api.admin.oauth.token_endpoint'|trans }}</span>
+                                </div>
+                            </div>
+                            <div class="col mb-2">
+                                <input type="text" class="form-control copy-secret" value="{{ url('oauth2_token') }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-3">
+                                <div class="d-inline-block">
+                                    <span>{{ 'api.admin.oauth.api_endpoint'|trans }}</span>
+                                </div>
+                            </div>
+                            <div class="col mb-2">
+                                <input type="text" class="form-control copy-secret" value="{{ url('api') }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <div id="create-client" class="d-block mb-3">
                     <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_new') }}">{{ 'admin.common.registration__new'|trans }}</a>
                 </div>


### PR DESCRIPTION
close #95

OAuth管理にエンドポイントをコピーできる機能を追加しました。
クライアントIDをコピーするのと同じUIでコピーできます。

![image](https://user-images.githubusercontent.com/16895409/92093002-c11b5180-ee0d-11ea-92d5-2dca8a8980a9.png)
