### PR TITLE
EC-CUBE4.1対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,21 +70,10 @@ install:
 script: |
   if [[ $ECCUBE_VERSION = '4.0.5' ]]
   then
-    while read TESTCASE
+    find app/Plugin/${PLUGIN_CODE}/Tests -name "*Test.php" | while read TESTCASE
     do
-      ./vendor/bin/phpunit --include-path vendor/kiy0taka/eccube4-test-fixer/src --loader 'Eccube\PHPUnit\Loader\Eccube4CompatTestSuiteLoader' app/Plugin/${PLUGIN_CODE}/Tests/${TESTCASE}
-    done <<EOF
-  Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
-  Web/Admin/LoginControllerTest.php
-  Web/Admin/OAuthControllerTest.php
-  Web/ApiControllerTest.php
-  GraphQL/SchemaTest.php
-  GraphQL/Mutation/UpdateProductStockMutationTest.php
-  GraphQL/Mutation/UpdateShippedMutationTest.php
-  GraphQL/TypesTest.php
-  GraphQL/AllowListTest.php
-  Service/WebHookServiceTest.php
-  EOF
+      ./vendor/bin/phpunit --include-path vendor/kiy0taka/eccube4-test-fixer/src --loader 'Eccube\PHPUnit\Loader\Eccube4CompatTestSuiteLoader' ${TESTCASE}
+    done
   else
     ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,29 @@ install:
   - *install_eccube
   - *package_api_setup
   - *eccube_setup
+  - composer require --dev kiy0taka/eccube4-test-fixer
 
-script:
-  -  ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests;
+script: |
+  if [[ $ECCUBE_VERSION = '4.0.5' ]]
+  then
+    while read TESTCASE
+    do
+      ./vendor/bin/phpunit --include-path vendor/kiy0taka/eccube4-test-fixer/src --loader 'Eccube\PHPUnit\Loader\Eccube4CompatTestSuiteLoader' app/Plugin/${PLUGIN_CODE}/Tests/${TESTCASE}
+    done <<EOF
+  Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+  Web/Admin/LoginControllerTest.php
+  Web/Admin/OAuthControllerTest.php
+  Web/ApiControllerTest.php
+  GraphQL/SchemaTest.php
+  GraphQL/Mutation/UpdateProductStockMutationTest.php
+  GraphQL/Mutation/UpdateShippedMutationTest.php
+  GraphQL/TypesTest.php
+  GraphQL/AllowListTest.php
+  Service/WebHookServiceTest.php
+  EOF
+  else
+    ./vendor/bin/phpunit app/Plugin/${PLUGIN_CODE}/Tests
+  fi
 
 #after_script:
 #  # disable plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ env:
     PLUGIN_CODE=Api
     ECCUBE_PACKAGE_API_URL=http://127.0.0.1:8080
   matrix:
-    - DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
-    - DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+    - ECCUBE_VERSION=4.0.5 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+    - ECCUBE_VERSION=4.0.5 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
+    - ECCUBE_VERSION=4.1 DATABASE_URL=mysql://root:@localhost/cube4_dev DATABASE_SERVER_VERSION=5
+    - ECCUBE_VERSION=4.1 DATABASE_URL=postgres://postgres:password@localhost/cube4_dev DATABASE_SERVER_VERSION=9
 
 before_install: &php_setup |
   echo "opcache.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -37,8 +39,9 @@ install_eccube: &install_eccube |
   tar cvzf ${HOME}/${PLUGIN_CODE}.tar.gz ./*
   git clone https://github.com/EC-CUBE/ec-cube.git
   cd ec-cube
-  git checkout experimental/plugin_bundle
-  composer selfupdate --1
+  git checkout ${ECCUBE_VERSION}
+  if [[ $ECCUBE_VERSION = '4.0.5' ]]; then composer selfupdate --1 ; fi
+  if [[ $ECCUBE_VERSION = '4.1' ]]; then composer selfupdate ; fi
   composer install --dev --no-interaction -o --apcu-autoloader
 
 package_api_setup: &package_api_setup |

--- a/DependencyInjection/ApiExtension.php
+++ b/DependencyInjection/ApiExtension.php
@@ -33,6 +33,7 @@ class ApiExtension extends Extension implements PrependExtensionInterface
                     'security' => true,
                     'stateless' => true,
                     'oauth2' => true,
+                    'provider' => 'member_provider'
                 ];
             }
             $replaced[$name] = $origin[$name];

--- a/GraphQL/Mutation/UpdateProductStockMutation.php
+++ b/GraphQL/Mutation/UpdateProductStockMutation.php
@@ -13,7 +13,7 @@
 
 namespace Plugin\Api\GraphQL\Mutation;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
 use GraphQL\Type\Definition\Type;
@@ -34,14 +34,14 @@ class UpdateProductStockMutation implements Mutation
     private $productClassRepository;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $entityManager;
 
     public function __construct(
         Types $types,
         ProductClassRepository $productClassRepository,
-        EntityManager $entityManager
+        EntityManagerInterface $entityManager
     ) {
         $this->types = $types;
         $this->productClassRepository = $productClassRepository;

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -13,7 +13,7 @@
 
 namespace Plugin\Api\GraphQL\Mutation;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Master\OrderStatus;
 use Eccube\Entity\Order;
@@ -40,7 +40,7 @@ class UpdateShippedMutation implements Mutation
     private $eccubeConfig;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $entityManager;
 
@@ -71,7 +71,7 @@ class UpdateShippedMutation implements Mutation
 
     public function __construct(
         EccubeConfig $eccubeConfig,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         MailService $mailService,
         OrderStateMachine $orderStateMachine,
         OrderStatusRepository $orderStatusRepository,

--- a/GraphQL/Query/SearchFormQuery.php
+++ b/GraphQL/Query/SearchFormQuery.php
@@ -16,7 +16,7 @@ namespace Plugin\Api\GraphQL\Query;
 use Eccube\Common\EccubeConfig;
 use Eccube\Util\StringUtil;
 use GraphQL\Type\Definition\Type;
-use Knp\Component\Pager\Paginator;
+use Knp\Component\Pager\PaginatorInterface;
 use Plugin\Api\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api\GraphQL\Query;
 use Plugin\Api\GraphQL\Type\ConnectionType;
@@ -24,14 +24,14 @@ use Plugin\Api\GraphQL\Types;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 abstract class SearchFormQuery implements Query
 {
     /**
-     * @var Paginator
+     * @var PaginatorInterface
      */
     private $paginator;
 
@@ -41,7 +41,7 @@ abstract class SearchFormQuery implements Query
     private $eccubeConfig;
 
     /**
-     * @var FormFactory
+     * @var FormFactoryInterface
      */
     private $formFactory;
 
@@ -53,7 +53,7 @@ abstract class SearchFormQuery implements Query
     /**
      * @required
      */
-    public function setPaginator(Paginator $paginator): void
+    public function setPaginator(PaginatorInterface $paginator): void
     {
         $this->paginator = $paginator;
     }
@@ -69,7 +69,7 @@ abstract class SearchFormQuery implements Query
     /**
      * @required
      */
-    public function setFormFactory(FormFactory $formFactory): void
+    public function setFormFactory(FormFactoryInterface $formFactory): void
     {
         $this->formFactory = $formFactory;
     }

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -68,6 +68,9 @@ services:
     nyholm.psr7.httplug_factory:
         class: Nyholm\Psr7\Factory\HttplugFactory
 
+
+    Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory: '@sensio_framework_extra.psr7.http_message_factory'
+
     core.api.allow_list:
         class: ArrayObject
         tags: ['eccube.api.allow_list']

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -14,8 +14,8 @@ api:
       secret_tooltip: Up to 128 alphanumeric characters
       scope: Scope
       scope_tooltip: GraphQL Query requires read, Mutation requires write/write Scope
-      scope.read.description: Read %shop_name% data
-      scope.write.description: Write %shop_name% data
+      scope.read.description: 'Read %shop_name% data'
+      scope.write.description: 'Write %shop_name% data'
       redirect_uri: Redirect URI
       redirect_uri_tooltip: You can enter multiple URIs separated by commas
       grant_type: Grant Type
@@ -26,7 +26,7 @@ api:
       clear_expired_tokens: Clears all expired access and/or refresh tokens
       copy: Copy
       copied: Copied
-      allow__confirm_message: Do you want to allow access this app to %shop_name%?
+      allow__confirm_message: 'Do you want to allow access this app to %shop_name%?'
       allow__confirm_description: 'Allow this app to:'
       allow: Allow
       deny: Deny

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -14,8 +14,8 @@ api:
       secret_tooltip: 128文字以下の半角英数
       scope: スコープ
       scope_tooltip: GraphQLのQueryにはread, Mutationにはwrite/writeのScopeが必要
-      scope.read.description: %shop_name%のデータに対する読み取り
-      scope.write.description: %shop_name%のデータに対する書き込み
+      scope.read.description: '%shop_name%のデータに対する読み取り'
+      scope.write.description: '%shop_name%のデータに対する書き込み'
       redirect_uri: リダイレクトURI
       redirect_uri_tooltip: カンマ区切りで複数のURIを入力可能
       grant_type: グラントタイプ
@@ -26,7 +26,7 @@ api:
       clear_expired_tokens: 期限切れのアクセストークンとリフレッシュトークンを削除する
       copy: コピーする
       copied: コピーしました
-      allow__confirm_message: アプリから%shop_name%へのアクセスを許可しますか？
+      allow__confirm_message: 'アプリから%shop_name%へのアクセスを許可しますか？'
       allow__confirm_description: 'このアプリに以下を許可します:'
       allow: 許可する
       deny: 許可しない

--- a/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
@@ -31,8 +31,8 @@ class UpdateProductStockMutationTest extends EccubeTestCase
     public function setUp()
     {
         parent::setUp();
-        $types = $this->container->get(Types::class);
-        $this->productClassRepository = $this->container->get(ProductClassRepository::class);
+        $types = self::$container->get(Types::class);
+        $this->productClassRepository = self::$container->get(ProductClassRepository::class);
         $this->updateProductStockMutation = new UpdateProductStockMutation($types, $this->productClassRepository, $this->entityManager);
 
         // テスト用の商品を作成

--- a/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
@@ -42,11 +42,11 @@ class UpdateShippedMutationTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $mailService = $this->container->get(MailService::class);
-        $orderStateMachine = $this->container->get(OrderStateMachine::class);
-        $orderStatusRepository = $this->container->get(OrderStatusRepository::class);
-        $types = $this->container->get(Types::class);
-        $shippingRepository = $this->container->get(ShippingRepository::class);
+        $mailService = self::$container->get(MailService::class);
+        $orderStateMachine = self::$container->get(OrderStateMachine::class);
+        $orderStatusRepository = self::$container->get(OrderStatusRepository::class);
+        $types = self::$container->get(Types::class);
+        $shippingRepository = self::$container->get(ShippingRepository::class);
 
         $this->updateShippedMutation = new UpdateShippedMutation(
             $this->eccubeConfig,

--- a/Tests/GraphQL/SchemaTest.php
+++ b/Tests/GraphQL/SchemaTest.php
@@ -403,7 +403,7 @@ class SchemaTest extends EccubeTestCase
     {
         $op = OperationParams::create(['query' => $query, 'variables' => $variables], $readonly);
         $helper = new Helper();
-        $config = ServerConfig::create()->setSchema($this->container->get(Schema::class));
+        $config = ServerConfig::create()->setSchema(self::$container->get(Schema::class));
         $result = $helper->executeOperation($config, $op);
         self::assertInstanceOf(ExecutionResult::class, $result);
 

--- a/Tests/GraphQL/TypesTest.php
+++ b/Tests/GraphQL/TypesTest.php
@@ -28,7 +28,7 @@ class TypesTest extends EccubeTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->types = $this->container->get(Types::class);
+        $this->types = self::$container->get(Types::class);
     }
 
     /**

--- a/Tests/Service/WebHookServiceTest.php
+++ b/Tests/Service/WebHookServiceTest.php
@@ -29,7 +29,7 @@ class WebHookServiceTest extends EccubeTestCase
     {
         parent::setUp();
 
-        $this->service = $this->container->get(WebHookService::class);
+        $this->service = self::$container->get(WebHookService::class);
     }
 
     public function testCreateRequest_withSecret()

--- a/Tests/Web/Admin/LoginControllerTest.php
+++ b/Tests/Web/Admin/LoginControllerTest.php
@@ -41,7 +41,7 @@ class LoginControllerTest extends AbstractWebTestCase
             ]
         );
 
-        $this->assertNotNull($this->container->get('security.token_storage')->getToken(), 'ログインしているかどうか');
+        $this->assertNotNull(self::$container->get('security.token_storage')->getToken(), 'ログインしているかどうか');
     }
 
     public function testRoutingAdminLogin_ログインしていない場合はログイン画面を表示()

--- a/Tests/Web/Admin/OAuthControllerTest.php
+++ b/Tests/Web/Admin/OAuthControllerTest.php
@@ -32,7 +32,7 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
     {
         parent::setUp();
 
-        $this->clientManager = $this->container->get(ClientManager::class);
+        $this->clientManager = self::$container->get(ClientManager::class);
     }
 
     public function testRoutingAdminSettingSystemOAuth2Client()

--- a/Tests/Web/ApiControllerTest.php
+++ b/Tests/Web/ApiControllerTest.php
@@ -40,10 +40,10 @@ class ApiControllerTest extends AbstractWebTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->clientManager = $this->container->get(ClientManager::class);
-        $this->clientRepository = $this->container->get(ClientRepositoryInterface::class);
-        $this->accessTokenRepository = $this->container->get(AccessTokenRepositoryInterface::class);
-        $this->authorizationServer = $this->container->get(AuthorizationServer::class);
+        $this->clientManager = self::$container->get(ClientManager::class);
+        $this->clientRepository = self::$container->get(ClientRepositoryInterface::class);
+        $this->accessTokenRepository = self::$container->get(AccessTokenRepositoryInterface::class);
+        $this->authorizationServer = self::$container->get(AuthorizationServer::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-  "name": "ec-cube/Api",
-  "version": "1.0.0",
+  "name": "ec-cube/api",
+  "version": "2.0.0",
   "description": "Web API",
   "type": "eccube-plugin",
   "require": {
-    "ec-cube/plugin-installer": "~0.0.6",
+    "ec-cube/plugin-installer": "~0.0.6 || ^2.0@dev",
     "trikoder/oauth2-bundle": "^2.1",
     "nyholm/psr7": "^1.2",
     "webonyx/graphql-php": "^14.0"


### PR DESCRIPTION
## TODO
- [x] ユニットテスト修正
   - ~~4.1 ブランチでプラグインの `@Route` アノテーションを認識してくれない~~
   - [4.1 では self::$container を使用する必要がある](https://symfony.com/blog/new-in-symfony-4-1-simpler-service-testing)
   - ~~4.0 と 4.1 のユニットテストを両立させる術が無いかも~~ [kiy0taka/eccube4-test-fixer](https://packagist.org/packages/kiy0taka/eccube4-test-fixer) を使用することで解決
