### PR TITLE
Symfony5.3からdeprecatedなgetMasterRequestをgetMainRequestに変更

### DIFF
--- a/EventListener/AuthorizationRequestResolveListener.php
+++ b/EventListener/AuthorizationRequestResolveListener.php
@@ -56,7 +56,7 @@ final class AuthorizationRequestResolveListener implements EventSubscriberInterf
     public function onAuthorizationRequestResolve(AuthorizationRequestResolveEvent $event): void
     {
         $user = $event->getUser();
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
 
         // システム管理者以外は承認しない
         if (!$user instanceof Member || $user->getAuthority()->getId() !== Authority::ADMIN) {

--- a/Service/WebHookService.php
+++ b/Service/WebHookService.php
@@ -62,7 +62,7 @@ class WebHookService implements EventSubscriberInterface
 
     public function fire(ResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 


### PR DESCRIPTION
Symfony5.3からdeprecatedで6.0からremoveになるgetMasterRequestを変更しました