### PR TITLE
Support grant_type=password

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,6 @@ jobs:
         bin/console eccube:plugin:enable --code=${PLUGIN_CODE}
         bin/console doctrine:schema:update --force --dump-sql
         bin/console cache:clear --no-warmup
-        bin/console league:oauth2-server:create-client --redirect-uri=http://127.0.0.1:8000/ --grant-type=authorization_code --grant-type=client_credentials --grant-type=implicit --grant-type=password --grant-type=refresh_token --scope=read --scope=write test
         rm codeception/_support/*Tester.php
         chmod 600 app/PluginData/Api42/oauth/private.key
 

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -108,7 +108,7 @@ class OAuthController extends AbstractController
             $secret = $form->get('secret')->getData();
 
             try {
-                $client = new Client($name, $identifier, $secret);
+                $client = new Client($name, $identifier, null); // FIXME Set client_secret to null
                 $client = $this->updateClientFromForm($client, $form);
 
                 $this->clientManager->save($client);
@@ -209,16 +209,10 @@ class OAuthController extends AbstractController
         );
         $client->setRedirectUris(...$redirectUris);
 
-        $grants = array_map(
-            function (string $grant): Grant {
-                return new Grant($grant);
-            },
-            $form->get('grants')->getData()
-        );
-        // authorization code grant が選択されていた場合には refresh token grant も付与
-        if (in_array(OAuth2Grants::AUTHORIZATION_CODE, $grants)) {
-            array_push($grants, new Grant(OAuth2Grants::REFRESH_TOKEN));
-        }
+        $grants = [
+            new Grant(OAuth2Grants::PASSWORD),
+            new Grant(OAuth2Grants::REFRESH_TOKEN)
+        ];
         $client->setGrants(...$grants);
 
         $scopes = array_map(

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -108,7 +108,7 @@ class OAuthController extends AbstractController
             $secret = $form->get('secret')->getData();
 
             try {
-                $client = new Client($name, $identifier, null); // FIXME Set client_secret to null
+                $client = new Client($name, $identifier, $secret);
                 $client = $this->updateClientFromForm($client, $form);
 
                 $this->clientManager->save($client);
@@ -209,10 +209,14 @@ class OAuthController extends AbstractController
         );
         $client->setRedirectUris(...$redirectUris);
 
-        $grants = [
-            new Grant(OAuth2Grants::PASSWORD),
-            new Grant(OAuth2Grants::REFRESH_TOKEN)
-        ];
+        $grants = array_map(
+            function (string $grant): Grant {
+                return new Grant($grant);
+            },
+            $form->get('grants')->getData()
+        );
+        array_push($grants, new Grant(OAuth2Grants::REFRESH_TOKEN)); // RefreshToken は常に利用可能
+
         $client->setGrants(...$grants);
 
         $scopes = array_map(

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -39,10 +39,12 @@ league_oauth2_server:
         doctrine: null
 
 services:
-    Plugin\Api42\EventListener\UserResolveListener:
+    Symfony\Component\Security\Core\User\UserProviderInterface: '@security.user_providers'
+    api.event.user_resolve:
+        class: Plugin\Api42\EventListener\UserResolveListener
         arguments:
-            # - '@Eccube\Security\Core\User\MemberProvider'
-            - '@Eccube\Security\Core\User\CustomerProvider' # FIXME
+            - '@Eccube\Security\Core\User\CustomerProvider'
+            - '@Eccube\Security\Core\User\MemberProvider'
             - '@Eccube\Security\Core\User\UserPasswordHasher'
         tags:
             - { name: kernel.event_listener, event: league.oauth2_server.event.user_resolve, method: onUserResolve }

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -17,7 +17,7 @@ league_oauth2_server:
         enable_client_credentials_grant: false
 
       # Whether to enable the password grant
-        enable_password_grant: false
+        enable_password_grant: true
 
       # Whether to enable the refresh token grant
         enable_refresh_token_grant: true
@@ -41,7 +41,8 @@ league_oauth2_server:
 services:
     Plugin\Api42\EventListener\UserResolveListener:
         arguments:
-            - '@Eccube\Security\Core\User\MemberProvider'
+            # - '@Eccube\Security\Core\User\MemberProvider'
+            - '@Eccube\Security\Core\User\CustomerProvider' # FIXME
             - '@Eccube\Security\Core\User\UserPasswordHasher'
         tags:
             - { name: kernel.event_listener, event: league.oauth2_server.event.user_resolve, method: onUserResolve }

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -15,7 +15,7 @@ api:
       identifier: Client ID
       identifier_tooltip: Up to 32 alphanumeric characters
       secret: Client Secret
-      secret_tooltip: Up to 128 alphanumeric characters
+      secret_tooltip: Up to 128 alphanumeric characters, Required if Authorization code grant is specified
       scope: Scope
       scope_tooltip: GraphQL Query requires read, Mutation requires write/write Scope
       scope.read.description: 'Read %shop_name% data'
@@ -23,7 +23,7 @@ api:
       redirect_uri: Redirect URI
       redirect_uri_tooltip: You can enter multiple URIs separated by commas
       grant_type: Grant Type
-      grant_type_tooltip: Supports only authorization code grant
+      grant_type_tooltip: Authorization code grant and Password grant are supported
       client_registration: Client Registration
       delete__confirm_title: Delete a Client
       delete__confirm_message: Are you sure to delete this Client?
@@ -34,6 +34,7 @@ api:
       allow__confirm_description: 'Allow this app to:'
       allow: Allow
       deny: Deny
+      client_secret.required: 'Please enter client_secret if you specify Authorization code grant.'
     webhook:
       management:  WebHook
       registration: WebHook Registration

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -15,7 +15,7 @@ api:
       identifier: クライアントID
       identifier_tooltip: 32文字以下の半角英数
       secret: クライアントシークレット
-      secret_tooltip: 128文字以下の半角英数
+      secret_tooltip: 128文字以下の半角英数。Authorization code grant を指定した場合は必須
       scope: スコープ
       scope_tooltip: GraphQLのQueryにはread, Mutationにはwrite/writeのScopeが必要
       scope.read.description: '%shop_name%のデータに対する読み取り'
@@ -23,7 +23,7 @@ api:
       redirect_uri: リダイレクトURI
       redirect_uri_tooltip: カンマ区切りで複数のURIを入力可能
       grant_type: グラントタイプ
-      grant_type_tooltip: Authorization code grantのみサポート
+      grant_type_tooltip: Authorization code grant 及び Password grant に対応
       client_registration: OAuthクライアント登録
       delete__confirm_title: OAuthクライアントを削除します。
       delete__confirm_message: OAuthクライアントを削除してよろしいですか？
@@ -34,6 +34,7 @@ api:
       allow__confirm_description: 'このアプリに以下を許可します:'
       allow: 許可する
       deny: 許可しない
+      client_secret.required: 'Authorization code grant を指定した場合は client_secret を入力してください。'
     webhook:
       management:  WebHook管理
       registration: WebHook登録

--- a/Resource/template/admin/OAuth/edit.twig
+++ b/Resource/template/admin/OAuth/edit.twig
@@ -61,9 +61,6 @@ file that was distributed with this source code.
                                         <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.secret_tooltip'|trans }}">
                                             <span>{{ 'api.admin.oauth.secret'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ms-1"></i>
-                                            <span class="badge bg-primary ms-1">
-                                                {{ 'admin.common.required'|trans }}
-                                            </span>
                                         </label>
                                     </div>
                                     <div class="col">

--- a/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
@@ -15,20 +15,29 @@ namespace Plugin\Api42\Tests\Web\Admin\OAuth2Bundle;
 
 use Eccube\Common\Constant;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Grant;
+use League\Bundle\OAuth2ServerBundle\Model\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\Model\Scope;
+use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
 use Symfony\Component\HttpFoundation\Response;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
 
 class AuthorizationControllerTest extends AbstractAdminWebTestCase
 {
+    /** @var Client */
+    private $OAuth2Client;
+
     public function setUp(): void
     {
         parent::setUp();
+        $this->OAuth2Client = $this->createOAuth2Client();
     }
 
     public function testRoutingAdminOauth2Authorize_ログインしている場合は権限移譲確認画面を表示()
     {
         /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->OAuth2Client;
 
         $this->client->request('GET',
                                $this->generateUrl(
@@ -53,7 +62,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminOauth2Authorize_権限移譲を許可()
     {
         /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->OAuth2Client;
         $authorize_url = $this->generateUrl(
             'oauth2_authorize',
             [
@@ -98,7 +107,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
     public function testRoutingAdminOauth2Authorize_権限移譲を許可しない()
     {
         /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->OAuth2Client;
         $authorize_url = $this->generateUrl(
             'oauth2_authorize',
             [
@@ -170,5 +179,24 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         parse_str($url['query'], $redirectParams);
 
         return $redirectParams;
+    }
+
+    private function createOAuth2Client(): Client
+    {
+        $client_id = hash('md5', random_bytes(16));
+        $client_secret = hash('sha256', random_bytes(32));
+        $Client = new Client('', $client_id, $client_secret);
+        $Client
+            ->setScopes(new Scope('read'))
+            ->setRedirectUris(new RedirectUri('http://127.0.0.1:8000/'))
+            ->setGrants(
+                new Grant(OAuth2Grants::AUTHORIZATION_CODE),
+                new Grant(OAuth2Grants::REFRESH_TOKEN)
+            )
+            ->setActive(true);
+        $clientManager = self::$container->get(ClientManagerInterface::class);
+        $clientManager->save($Client);
+
+        return $Client;
     }
 }

--- a/Tests/Web/OAuth2Bundle/TokenControllerWithROPCTest.php
+++ b/Tests/Web/OAuth2Bundle/TokenControllerWithROPCTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api42\Tests\Web\OAuth2Bundle;
+
+use Eccube\Entity\Customer;
+use Eccube\Tests\Web\AbstractWebTestCase;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\Model\Grant;
+use League\Bundle\OAuth2ServerBundle\Model\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\Model\Scope;
+use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
+
+class TokenControllerWithROPCTest extends AbstractWebTestCase
+{
+    protected ?Client $OAuth2Client;
+    protected ?Customer $Customer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->OAuth2Client = $this->createOAuth2Client();
+        $this->Customer = $this->createCustomer();
+    }
+
+    public function testGetInstance()
+    {
+        $this->client->request(
+            'POST',
+            $this->generateUrl('oauth2_token'),
+            [
+                'grant_type' => OAuth2Grants::PASSWORD,
+                'client_id' => $this->OAuth2Client->getIdentifier(),
+                'username' => $this->Customer->getEmail(),
+                'password' => 'password',
+                'scope' => 'read write'
+            ]
+        );
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('access_token', $response);
+        self::assertArrayHasKey('refresh_token', $response);
+        self::assertSame('Bearer', $response['token_type']);
+        self::assertSame(3600, $response['expires_in']);
+
+        $parser = new Parser(new JoseEncoder());
+        $token = $parser->parse($response['access_token']);
+
+        self::assertTrue($token->isRelatedTo($this->Customer->getEmail()), 'Token is not related to customer(sub)');
+        self::assertFalse($token->isExpired(new \DateTimeImmutable('+3590 second')), 'Token is expired(exp)');
+        self::assertTrue($token->isPermittedFor($this->OAuth2Client->getIdentifier()), 'Token is not permitted for client(aud)');
+        self::assertTrue($token->hasBeenIssuedBefore(new \DateTimeImmutable('+1 second')), 'Token has not been issued before(iat)');
+        self::assertTrue($token->isMinimumTimeBefore(new \DateTimeImmutable('+1 second')), 'Token is not minimum time before(nbf)');
+    }
+
+    protected function createOAuth2Client(): Client
+    {
+        $client_id = hash('md5', random_bytes(16));
+        $Client = new Client('', $client_id, null); // public client
+        $Client
+            ->setScopes(
+                new Scope('read'),
+                new Scope('write')
+            )
+            ->setRedirectUris(new RedirectUri('http://127.0.0.1:8000/'))
+            ->setGrants(
+                new Grant(OAuth2Grants::PASSWORD),
+                new Grant(OAuth2Grants::REFRESH_TOKEN)
+            )
+            ->setActive(true);
+
+        $clientManager = self::$container->get(ClientManagerInterface::class);
+        $clientManager->save($Client);
+
+        return $Client;
+    }
+}


### PR DESCRIPTION
refs https://github.com/EC-CUBE/next-poc/issues/57

## TODO
- [x] OAuth 管理画面で grant_type=password を選択できるようにする
   -  grant_type=password の場合は client_secret に  null を設定できるようにする
- [x] `Plugin\Api42\EventListener\UserResolveListener` で MemberProvider, CustomerProvider の両方を使用できるようにする