### PR TITLE
Mutation で FormType を InputObjectType 経由で利用できるようにする

### DIFF
--- a/GraphQL/Mutation/AbstractMutation.php
+++ b/GraphQL/Mutation/AbstractMutation.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api42\GraphQL\Mutation;
+use Eccube\Form\Type\FormTypeWrapper;
+use Eccube\Form\Type\MasterType;
+use Eccube\Form\Type\Master\SexType;
+use Eccube\Form\Type\RepeatedEmailType;
+use Eccube\Form\Type\RepeatedPasswordType;
+use Eccube\Util\StringUtil;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use Plugin\Api42\GraphQL\Error\InvalidArgumentException;
+use Plugin\Api42\GraphQL\Mutation;
+use Plugin\Api42\GraphQL\Type\Definition\DateTimeType;
+use Plugin\Api42\GraphQL\Types;
+use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+
+abstract class AbstractMutation implements Mutation
+{
+    private FormFactoryInterface $formFactory;
+
+    private Types $types;
+
+    abstract public function getName(): string;
+
+    abstract public function getArgsType(): string;
+
+    abstract public function getTypesClass(): string;
+
+    abstract protected function executeMutation($root, array $args): mixed;
+
+    protected function getInputObject(FormInterface $form): InputObjectType
+    {
+        $fields = [];
+        $this->convertArgs($form, $fields);
+        return new InputObjectType([
+            'name' => $form->getName().'Input',
+            'fields' => $fields,
+        ]);
+    }
+
+    protected function getParentProperty(&$prop, FormInterface $form)
+    {
+        if ($form->getParent() && !$form->getParent()->isRoot()) {
+            $prop = $form->getParent()->getName().'_'.$prop;
+            $this->getParentProperty($prop, $form->getParent());
+        }
+    }
+
+    protected function convertArgs(FormInterface $form, array &$args = []): void
+    {
+        $formConfig = $form->getConfig();
+        $innerTypes = [
+            BirthdayType::class,
+            SexType::class,
+            RepeatedEmailType::class,
+            RepeatedPasswordType::class,
+            IntegerType::class,
+        ];
+        $innerType = $formConfig->getType()->getInnerType();
+
+        if ($innerType instanceof FormTypeWrapper) {
+            // XXX FormTypeWrapper::type is private
+            $refClass = new \ReflectionObject($innerType);
+            $refProp = $refClass->getProperty('type');
+            $refProp->setAccessible(true);
+            $innerType = $refProp->getValue($innerType);
+        }
+        $typeClass = get_class($innerType);
+
+        if (in_array($typeClass, $innerTypes) || count($form) === 0) {
+            $type = Type::string();
+            if ($innerType->getParent() === MasterType::class) {
+                $type = Type::int();
+            }
+            switch ($typeClass) {
+                case IntegerType::class:
+                    $type = Type::int();
+                    break;
+                case BirthdayType::class:
+                    $type = DateTimeType::dateTime();
+                    break;
+                case RepeatedEmailType::class:
+                case RepeatedPasswordType::class:
+                    $type = Type::string();
+                    break;
+            }
+            if ($formConfig->getOption('multiple')) {
+                $type = Type::listOf($type);
+            }
+            if ($formConfig->getOption('required') && !$formConfig->getOption('multiple')) {
+                $type = Type::nonNull($type);
+            }
+            $defaultValue = $form->getViewData();
+            $prop = '';
+            $this->getParentProperty($prop, $form);
+            $args[$prop.$form->getName()] = [
+                'type' => $type,
+                'defaultValue' => StringUtil::isNotBlank($defaultValue) ? $defaultValue : null,
+                'description' => $formConfig->getOption('label') ? trans($formConfig->getOption('label')) : null,
+            ];
+        } else {
+            foreach ($form as $child) {
+                $this->convertArgs($child, $args);
+            }
+        }
+    }
+
+    public function getMutation(): array
+    {
+        $builder = $this->formFactory->createBuilder($this->getArgsType(), null, ['csrf_protection' => false]);
+        $form = $builder->getForm();
+
+        return [
+            'type' => $this->types->get($this->getTypesClass()),
+            'args' => [
+                'input' => [
+                    'type' => $this->getInputObject($form),
+                ],
+            ],
+            'resolve' => function ($value, array $args, $context, ResolveInfo $info) use ($form) {
+                return $this->resolver($value, $args, $context, $info, $form);
+            }
+        ];
+    }
+
+    protected  function convertFormValues(FormInterface $form, &$formValues = [], $input = []): void
+    {
+        $innerTypes = [
+            BirthdayType::class,
+            SexType::class,
+            RepeatedEmailType::class,
+            RepeatedPasswordType::class,
+        ];
+        $innerType = $form->getConfig()->getType()->getInnerType();
+        $typeClass = get_class($innerType);
+
+        if ($innerType instanceof FormTypeWrapper) {
+            // XXX FormTypeWrapper::type is private
+            $refClass = new \ReflectionObject($innerType);
+            $refProp = $refClass->getProperty('type');
+            $refProp->setAccessible(true);
+            $typeClass = get_class((object)$refProp->getValue($innerType));
+        }
+
+        if (in_array($typeClass, $innerTypes) || count($form) === 0) {
+            $prop = '';
+            $this->getParentProperty($prop, $form);
+            if (array_key_exists($prop.$form->getName(), $input) && $input[$prop.$form->getName()] !== null) {
+                switch ($typeClass) {
+                    case BirthdayType::class:
+                        $formValues = [
+                            'year' => ($input[$prop.$form->getName()])->format('Y'),
+                            'month' => ($input[$prop.$form->getName()])->format('n'),
+                            'day' => ($input[$prop.$form->getName()])->format('j'),
+                        ];
+                        break;
+                    case RepeatedEmailType::class:
+                    case RepeatedPasswordType::class:
+                        $formValues = [
+                            'first' => $input[$prop.$form->getName()],
+                            'second' => $input[$prop.$form->getName()],
+                        ];
+                        break;
+                    default:
+                        $formValues = $input[$prop.$form->getName()];
+                }
+            }
+        } else {
+            foreach ($form as $child) {
+                $this->convertFormValues($child, $formValues[$child->getName()], $input);
+            }
+        }
+    }
+
+    protected function resolver($value, array $args, $context, ResolveInfo $info, FormInterface $form): mixed
+    {
+        $formValues = [];
+        $this->convertFormValues($form, $formValues, $args['input']);
+
+        $form->submit($formValues);
+        if (!$form->isValid()) {
+            $message = '';
+            foreach ($form->getErrors(true) as $error) {
+                $message .= sprintf('%s: %s;', $error->getOrigin()->getName(), $error->getMessage());
+            }
+
+            throw new InvalidArgumentException($message);
+        }
+
+        return $this->executeMutation($value, $form->getData());
+    }
+
+    public function setTypes(Types $types): self
+    {
+        $this->types = $types;
+
+        return $this;
+    }
+
+    public function getTypes(): Types
+    {
+        return $this->types;
+    }
+
+    public function setFormFactory(FormFactoryInterface $formFactory): self
+    {
+        $this->formFactory = $formFactory;
+
+        return $this;
+    }
+
+    public function getFormFactory(): FormFactoryInterface
+    {
+        return $this->formFactory;
+    }
+}

--- a/Tests/GraphQL/Mutation/EntryCustomerMutationTest.php
+++ b/Tests/GraphQL/Mutation/EntryCustomerMutationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api42\Tests\GraphQL\Mutation;
+
+use Eccube\Tests\EccubeTestCase;
+use GraphQL\GraphQL;
+use Plugin\Api42\GraphQL\Mutation\EntryCustomerMutation;
+use Plugin\Api42\GraphQL\Schema;
+
+class EntryCustomerMutationTest extends EccubeTestCase
+{
+    private ?EntryCustomerMutation $mutation;
+    private ?Schema $schema;
+
+    /**
+     * @var string
+     * @lang GraphQL
+     */
+    private const MUTATION = '
+mutation entryCustomer($input: entryInput) {
+  entryCustomer(
+    input: $input
+  ) {
+    id
+    name01
+    name02
+    kana01
+    kana02
+    company_name
+    email
+    postal_code
+    phone_number
+    addr01
+    addr02
+    Pref {
+      id,
+      name
+    }
+    Sex {
+      id
+      name
+    }
+    Job {
+      id
+      name
+    }
+  }
+}';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schema = self::$container->get(Schema::class);
+    }
+
+    public function testExecuteMutation()
+    {
+        $faker = $this->getFaker();
+
+        $birth = $faker->dateTimeBetween;
+        $name01 = $faker->lastName;
+        $name02 = $faker->firstName;
+        $kana01 = $faker->lastKanaName;
+        $kana02 = $faker->firstKanaName;
+        $company_name = $faker->company;
+        $postal_code = $faker->postcode;
+        $pref = 5;
+        $addr01 = $faker->city;
+        $addr02 = $faker->streetAddress;
+        $phone_number = $faker->phoneNumber;
+        $email = $faker->safeEmail;
+        $password = $faker->lexify('????????????').'a1';
+        $sex = 3;
+        $job = 1;
+
+        $variables = [
+            'input' => [
+                'name_name01' => $name01,
+                'name_name02' => $name02,
+                'kana_kana01' => $kana01,
+                'kana_kana02' => $kana02,
+                'company_name' => $company_name,
+                'postal_code' => $postal_code,
+                'address_addr01' => $addr01,
+                'address_addr02' => $addr02,
+                'address_pref' => $pref,
+                'email' => $email,
+                'plain_password' => $password,
+                'phone_number' => $phone_number,
+                'birth' => $birth->format(\DateTime::ATOM),
+                'sex' => $sex,
+                'job' => $job,
+            ]
+        ];
+
+        $result = GraphQL::executeQuery($this->schema,
+                              self::MUTATION,
+                              null,
+                              null,
+                              $variables
+        );
+
+        self::assertArrayHasKey('data', $result->toArray(), array_reduce($result->errors, function ($carry, $item) {
+            return $carry.$item->getMessage();
+        }, ''));
+
+        self::assertEquals($name01, $result->toArray()['data']['entryCustomer']['name01']);
+        self::assertEquals($name02, $result->toArray()['data']['entryCustomer']['name02']);
+        self::assertEquals($kana01, $result->toArray()['data']['entryCustomer']['kana01']);
+        self::assertEquals($kana02, $result->toArray()['data']['entryCustomer']['kana02']);
+        self::assertEquals($company_name, $result->toArray()['data']['entryCustomer']['company_name']);
+        self::assertEquals($email, $result->toArray()['data']['entryCustomer']['email']);
+        self::assertEquals($postal_code, $result->toArray()['data']['entryCustomer']['postal_code']);
+        self::assertEquals(str_replace('-', '', $phone_number), $result->toArray()['data']['entryCustomer']['phone_number']);
+        self::assertEquals($addr01, $result->toArray()['data']['entryCustomer']['addr01']);
+        self::assertEquals($addr02, $result->toArray()['data']['entryCustomer']['addr02']);
+        self::assertEquals($pref, $result->toArray()['data']['entryCustomer']['Pref']['id']);
+        self::assertEquals($sex, $result->toArray()['data']['entryCustomer']['Sex']['id']);
+        self::assertEquals($job, $result->toArray()['data']['entryCustomer']['Job']['id']);
+    }
+}


### PR DESCRIPTION
以下のようにリクエスト可能

```graphql
mutation entryCustomer($input: entryInput) {
  entryCustomer(
    input: $input
  ) {
    id
    name01
    name02
    email
    postal_code
    phone_number
    addr01
    addr02
    Pref {
      id,
      name
    }
  }
}
```
```graphql
{
   "input":{
      "name_name01":"あああ",
      "name_name02":"いいい",
      "kana_kana01":"アアア",
      "kana_kana02":"イイイ",
      "company_name":"corp",
      "postal_code":"4440426",
      "address_addr01":"aaa",
      "address_addr02":"222",
      "address_pref":5,
      "email":"user@example.com",
      "plain_password":"password.12345",
      "phone_number":"09017576666",
      "birth":"2000-01-01T00:00:00+09:00",
      "sex":1,
   }
}
```

## TODO

- [x] FormType の型情報から GraphQL の型情報を生成する
- [x] FormType の NotBlank 等のバリデーションを parseValue で利用できるようにする
- [x] `email_first` や `sex_1` を修正する
- [ ] FromType を拡張して InputsType を作成する
- [ ] FormType を拡張して ArgsType を作成する