### PR TITLE
Support Authorization header in GraphiQL

### DIFF
--- a/Resource/config/services_dev.yaml
+++ b/Resource/config/services_dev.yaml
@@ -1,0 +1,4 @@
+services:
+    Eccube\Security\SecurityContext:
+        class: Plugin\Api42\Security\GraphiQLSecurityContext
+        autowire: true

--- a/Resource/template/admin/OAuth/graphiql.twig
+++ b/Resource/template/admin/OAuth/graphiql.twig
@@ -165,17 +165,20 @@
   }
 }
 `;
-      const graphQLFetcher = graphQLParams =>
-        fetch('{{ url('admin_api_graphiql_api') }}', {
-          method: 'post',
-          headers: {
-            'Content-Type': 'application/json',
-            'ECCUBE-CSRF-TOKEN': '{{ csrf_token(constant('Eccube\\Common\\Constant::TOKEN_NAME')) }}'
-          },
-          body: JSON.stringify(graphQLParams),
-        })
-          .then(response => response.json())
-          .catch(() => response.text());
+     const graphQLFetcher = (graphQLParams, opts) => {
+         const { headers = {} } = opts;
+         return fetch('{{ url('admin_api_graphiql_api') }}', {
+             method: 'post',
+             headers: {
+                 'Content-Type': 'application/json',
+                 'ECCUBE-CSRF-TOKEN': '{{ csrf_token(constant('Eccube\\Common\\Constant::TOKEN_NAME')) }}',
+                 ...headers,
+             },
+             body: JSON.stringify(graphQLParams),
+         })
+             .then(response => response.json())
+             .catch(() => response.text());
+     };
       ReactDOM.render(
         React.createElement(GraphiQL, { fetcher: graphQLFetcher, defaultQuery: defaultQuery }),
         document.getElementById('graphiql'),

--- a/Security/GraphiQLSecurityContext.php
+++ b/Security/GraphiQLSecurityContext.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api42\Security;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Entity\Customer;
+use Eccube\Http\RequestStack;
+use Eccube\Security\SecurityContext;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\JwtFacade;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\RegisteredClaims;
+use Lcobucci\JWT\Validation\Constraint\StrictValidAt;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class GraphiQLSecurityContext extends SecurityContext
+{
+    private RequestStack $requestStack;
+    private EntityManagerInterface $entityManager;
+    private ContainerInterface $container;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        RequestStack $requestStack,
+        EntityManagerInterface $entityManager,
+        ContainerInterface $container
+    ) {
+        parent::__construct($tokenStorage, $authorizationChecker, $csrfTokenManager);
+        $this->requestStack = $requestStack;
+        $this->entityManager = $entityManager;
+        $this->container = $container;
+    }
+
+    public function getLoginUser()
+    {
+        $token = $this->getToken();
+        if (!$token) {
+            return null;
+        }
+        $request = $this->requestStack->getCurrentRequest();
+        if (null !== $request) {
+            $bearerToken = $request->headers->get('Authorization');
+            if ($bearerToken) {
+                $rawJwt = \trim((string) \preg_replace('/^\s*Bearer\s/', '', $bearerToken));
+
+                try {
+                    $jwt = (new JwtFacade())->parse(
+                        $rawJwt,
+                        new SignedWith(new Sha256, InMemory::file($this->container->getParameter('plugin_data_realdir').'/Api42/oauth/public.key')),
+                        new StrictValidAt(SystemClock::fromSystemTimezone())
+                    );
+
+                    $identifier = $jwt->claims()->get(RegisteredClaims::SUBJECT);
+
+                    return $this->entityManager->getRepository(Customer::class)->findOneBy(['email' => $identifier]);
+                } catch (\Exception $e) {
+                    log_error($e->getMessage(), [$e]);
+
+                    return null;
+                }
+            }
+        }
+
+        return $token->getUser();
+    }
+}


### PR DESCRIPTION
GraphiQL の headers に Customer のアクセストークンを Authorization  header で渡すことで、Customer の Query/Mutation が使用できる
![image](https://github.com/EC-CUBE/eccube-api4/assets/815715/9f4b5c13-050f-4d15-851c-f988f2273145)

- Member のアクセストークンは未対応
- GraphiQL の headers はリロードすると消えてしまう。 Settings Dialog の `Persist headers` を ON にすると保存できる(が、時折消えてしまう)
