### PR TITLE
ID型に対応

### DIFF
--- a/Form/Type/Front/AddCartType.php
+++ b/Form/Type/Front/AddCartType.php
@@ -22,6 +22,7 @@ use Eccube\Form\FormEvent;
 use Eccube\Form\Type\AbstractType;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Validator\Constraints as Assert;
+use Plugin\Api42\Form\Type\IdType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 class AddCartType extends AbstractType
@@ -48,7 +49,7 @@ class AddCartType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         $builder
-            ->add('product_class_id', IntegerType::class, [
+            ->add('product_class_id', IdType::class, [
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\Regex(['pattern' => '/^\d+$/']),

--- a/Form/Type/IdType.php
+++ b/Form/Type/IdType.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api42\Form\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class IdType extends TextType
+{
+}

--- a/GraphQL/Mutation/AbstractMutation.php
+++ b/GraphQL/Mutation/AbstractMutation.php
@@ -22,6 +22,7 @@ use GraphQL\Error\Error;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+use Plugin\Api42\Form\Type\IdType;
 use Plugin\Api42\GraphQL\Error\FormValidationException;
 use Plugin\Api42\GraphQL\Error\Info;
 use Plugin\Api42\GraphQL\Error\Warning;
@@ -81,6 +82,7 @@ abstract class AbstractMutation implements Mutation
             RepeatedEmailType::class,
             RepeatedPasswordType::class,
             IntegerType::class,
+            IdType::class,
         ];
         $innerType = $formConfig->getType()->getInnerType();
 
@@ -96,9 +98,12 @@ abstract class AbstractMutation implements Mutation
         if (in_array($typeClass, $innerTypes) || count($form) === 0) {
             $type = Type::string();
             if ($innerType->getParent() === MasterType::class) {
-                $type = Type::int();
+                $type = Type::Id();
             }
             switch ($typeClass) {
+                case IdType::class:
+                    $type = Type::id();
+                    break;
                 case IntegerType::class:
                     $type = Type::int();
                     break;


### PR DESCRIPTION
cartMutationにて、prodcut_class_id: stringで値を渡すとgraphql側ではint型を想定しておりエラーとなる。
graphqlの仕様では、ID値はstringで扱うべきとのこと なのでIntではなくstringとして扱うように変更
https://spec.graphql.org/October2021/#sec-ID


entryInputの場合、以下のようにスキーマが変わります。
```
type entryInput {
  name_name01: String!
  name_name02: String!
  kana_kana01: String!
  kana_kana02: String!
  company_name: String = null
  postal_code: String!
  address_pref: Int!
  address_addr01: String!
  address_addr02: String!
  phone_number: String!
  email: String!
  plain_password: String!
  birth: DateTime = null
  sex: Int = null
  job: Int = null
}
```
↓
```
type entryInput {
  name_name01: String!
  name_name02: String!
  kana_kana01: String!
  kana_kana02: String!
  company_name: String = null
  postal_code: String!
  address_pref: ID!
  address_addr01: String!
  address_addr02: String!
  phone_number: String!
  email: String!
  plain_password: String!
  birth: DateTime = null
  sex: ID = null
  job: ID = null
}
```