### PR TITLE
Entityの書き込みに対するScope制御

### DIFF
--- a/Doctrine/EventSubscriber/EntityListener.php
+++ b/Doctrine/EventSubscriber/EntityListener.php
@@ -14,47 +14,72 @@
 namespace Plugin\Api42\Doctrine\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\PreRemoveEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use GraphQL\Error\Error;
+use Plugin\Api42\GraphQL\EntityAccessPolicy;
 use Plugin\Api42\Service\WebHookEvents;
 
 class EntityListener implements EventSubscriber
 {
-    /**
-     * @var WebHookEvents
-     */
-    private $webHookEvents;
+    private WebHookEvents $webHookEvents;
+
+    private EntityAccessPolicy $accessPolicy;
 
     /**
      * EntityListener constructor.
-     * @param WebHookEvents $webHookEvents
      */
-    public function __construct(WebHookEvents $webHookEvents)
+    public function __construct(WebHookEvents $webHookEvents, EntityAccessPolicy $accessPolicy)
     {
         $this->webHookEvents = $webHookEvents;
+        $this->accessPolicy = $accessPolicy;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
+            Events::prePersist,
+            Events::preUpdate,
+            Events::preRemove,
             Events::postPersist,
             Events::postUpdate,
-            Events::preRemove,
         ];
     }
 
-    public function postPersist(LifecycleEventArgs $args)
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $this->validateEntityScope($args->getObject());
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $this->validateEntityScope($args->getObject());
+    }
+
+    public function postPersist(LifecycleEventArgs $args): void
     {
         $this->webHookEvents->onCreated($args->getObject());
     }
 
-    public function postUpdate(LifecycleEventArgs $args)
+    public function postUpdate(LifecycleEventArgs $args): void
     {
         $this->webHookEvents->onUpdated($args->getObject());
     }
 
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(PreRemoveEventArgs $args): void
     {
+        $this->validateEntityScope($args->getObject());
         $this->webHookEvents->onDeleted($args->getObject());
+    }
+
+    private function validateEntityScope(object $entity): void
+    {
+        $entityClass = get_class($entity);
+        if ($this->accessPolicy->canWriteEntity($entityClass) === false) {
+            throw new Error("Cannot write entity. `{$entityClass}`");
+        }
     }
 }

--- a/Tests/Web/ApiControllerTest.php
+++ b/Tests/Web/ApiControllerTest.php
@@ -90,6 +90,9 @@ class ApiControllerTest extends AbstractWebTestCase
             [['read:Customer'], '{ customer(id:1) { id, password } }', 'Cannot query field "password" on type "Customer".'],
             [null, '{ product(id:1) { id, name } }'],
             [null, '{ product(id:1) { id, name, Creator { id } } }', 'Cannot query field "Creator" on type "Product".'],
+            [['read:ProductClass'], 'mutation { updateProductStock(code: "sand-01", stock: 10, stock_unlimited:false) { id } }', 'Cannot write entity. `Eccube\\Entity\\ProductClass`'],
+            [['read:ProductClass', 'write:ProductClass'], 'mutation { updateProductStock(code: "sand-01", stock: 10, stock_unlimited:false) { id } }', 'Cannot write entity. `Eccube\\Entity\\ProductStock`'],
+            [['read:ProductClass', 'write:ProductClass', 'write:ProductStock'], 'mutation { updateProductStock(code: "sand-01", stock: 10, stock_unlimited:false) { id } }'],
         ];
     }
 


### PR DESCRIPTION
スコープ`read:Xxx`をチェックしてEntityの登録/更新/削除を制御するようにしました。
Doctrineのライフサイクルイベントで制御するようにしていますが、`/api`以外のルーティングではすべてを許可するようにしています。