### PR TITLE
GraphiQLが動作していないのでReactのバージョンを18に指定

### DIFF
--- a/Resource/template/admin/OAuth/graphiql.twig
+++ b/Resource/template/admin/OAuth/graphiql.twig
@@ -17,11 +17,11 @@
 {% block javascript %}
     <script
       crossorigin
-      src="https://unpkg.com/react/umd/react.production.min.js"
+      src="https://unpkg.com/react@18/umd/react.production.min.js"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
     ></script>
     <script
       crossorigin


### PR DESCRIPTION
GraphiQLが動作していないのでReactのバージョンを18に指定しました。