### PR TITLE
chome :phpstan level6とphpcsfixerを適用

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ on:
       - '**'
       - '!*.md'
   pull_request:
-    branches:
-      - '*'
     paths:
       - '**'
       - '!*.md'
@@ -137,6 +135,21 @@ jobs:
         bin/console league:oauth2-server:create-client --redirect-uri=http://127.0.0.1:8000/ --grant-type=authorization_code --grant-type=client_credentials --grant-type=implicit --grant-type=password --grant-type=refresh_token --scope=read --scope=write test
         rm codeception/_support/*Tester.php
         chmod 600 app/PluginData/Api44/oauth/private.key
+
+    - name: Run PHPStan
+      env:
+        APP_ENV: 'test'
+        APP_DEBUG: 0
+        DATABASE_URL: ${{ matrix.database_url }}
+        DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+        DATABASE_CHARSET: ${{ matrix.database_charset }}
+        PLUGIN_CODE: ${{ matrix.plugin_code }}
+        ECCUBE_PACKAGE_API_URL: 'http://127.0.0.1:8080'
+        USE_SELFSIGNED_SSL_CERTIFICATE: '1'
+      working-directory: 'ec-cube'
+      run: |
+        bin/console cache:clear --no-warmup
+        ./vendor/bin/phpstan analyse -c app/Plugin/${PLUGIN_CODE}/phpstan.neon.dist --no-progress
 
     - name: Run PHPUnit
       env:

--- a/ApiNav.php
+++ b/ApiNav.php
@@ -18,7 +18,7 @@ use Eccube\Common\EccubeNav;
 class ApiNav implements EccubeNav
 {
     /**
-     * @return array
+     * @return array<string, array<string, array<string, array<string, array<string, array<string, string>>|string>>>>
      */
     public static function getNav(): array
     {

--- a/Bundle/ApiBundle.php
+++ b/Bundle/ApiBundle.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ApiBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -20,6 +20,7 @@ use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\RefreshTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\AuthorizationCode;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\Model\ClientInterface;
 use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
@@ -70,7 +71,7 @@ class OAuthController extends AbstractController
      */
     #[Route(path: '/%eccube_admin_route%/api/config', name: 'admin_api_config', methods: ['GET'])]
     #[Route(path: '/%eccube_admin_route%/api/oauth', name: 'admin_api_oauth', methods: ['GET'])]
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
         $criteria = ClientFilter::create();
         $clients = $this->clientManager->list($criteria);
@@ -88,7 +89,7 @@ class OAuthController extends AbstractController
      * @throws \Exception
      */
     #[Route(path: '/%eccube_admin_route%/api/oauth/new', name: 'admin_api_oauth_new', methods: ['GET', 'POST'])]
-    public function create(Request $request)
+    public function create(Request $request): RedirectResponse|Response
     {
         $name = '';
 
@@ -129,7 +130,7 @@ class OAuthController extends AbstractController
      * @return RedirectResponse
      */
     #[Route(path: '/%eccube_admin_route%/api/oauth/delete/{identifier}', requirements: ['identifier' => '\w+'], name: 'admin_api_oauth_delete', methods: ['DELETE'])]
-    public function delete(Request $request, string $identifier)
+    public function delete(Request $request, string $identifier): RedirectResponse
     {
         $this->isTokenValid();
 
@@ -160,7 +161,7 @@ class OAuthController extends AbstractController
      * @return RedirectResponse
      */
     #[Route(path: '/%eccube_admin_route%/api/oauth/clear_expired_tokens', name: 'admin_api_oauth_clear_expired_tokens', methods: ['DELETE'])]
-    public function clearExpiredTokens(Request $request)
+    public function clearExpiredTokens(Request $request): RedirectResponse
     {
         try {
             $this->accessTokenManager->clearExpired();
@@ -219,11 +220,11 @@ class OAuthController extends AbstractController
     /**
      * AuthorizationCode が保存されている場合は削除
      *
-     * @param Client $client
+     * @param ClientInterface $client
      *
      * @return int
      */
-    private function deleteAuthorizationCode(Client $client): int
+    private function deleteAuthorizationCode(ClientInterface $client): int
     {
         return $this->entityManager->createQueryBuilder()
             ->delete(AuthorizationCode::class, 'ac')

--- a/Controller/Admin/WebHookController.php
+++ b/Controller/Admin/WebHookController.php
@@ -40,7 +40,7 @@ class WebHookController extends AbstractController
     }
 
     #[Route(path: '/%eccube_admin_route%/api/webhook', name: 'admin_api_webhook', methods: ['GET'])]
-    public function index()
+    public function index(): Response
     {
         $WebHooks = $this->webHookRepository->findAll();
 
@@ -57,7 +57,7 @@ class WebHookController extends AbstractController
      */
     #[Route(path: '/%eccube_admin_route%/api/webhook/new', name: 'admin_api_webhook_new', methods: ['GET', 'POST'])]
     #[Route(path: '/%eccube_admin_route%/api/webhook/edit/{id}', requirements: ['id' => '\d+'], name: 'admin_api_webhook_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, ?WebHook $WebHook = null)
+    public function edit(Request $request, ?WebHook $WebHook = null): RedirectResponse|Response
     {
         $WebHook = $WebHook ?: new WebHook();
         $builder = $this->formFactory->createBuilder(WebHookType::class, $WebHook);
@@ -85,7 +85,7 @@ class WebHookController extends AbstractController
      * @return RedirectResponse
      */
     #[Route(path: '/%eccube_admin_route%/api/webhook/delete/{id}', requirements: ['id' => '\d+'], name: 'admin_api_webhook_delete', methods: ['DELETE'])]
-    public function delete(WebHook $WebHook)
+    public function delete(WebHook $WebHook): RedirectResponse
     {
         $this->isTokenValid();
 

--- a/Controller/ApiController.php
+++ b/Controller/ApiController.php
@@ -19,8 +19,8 @@ use GraphQL\GraphQL;
 use GraphQL\Validator\DocumentValidator;
 use Plugin\Api44\GraphQL\Schema;
 use Plugin\Api44\GraphQL\ScopeValidationRule;
-use Plugin\Api44\GraphQL\Types;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -28,11 +28,6 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ApiController extends AbstractController
 {
-    /**
-     * @var Types
-     */
-    private Types $types;
-
     /**
      * @var KernelInterface
      */
@@ -49,12 +44,10 @@ class ApiController extends AbstractController
     private ScopeValidationRule $scopeValidationRule;
 
     public function __construct(
-        Types $types,
         KernelInterface $kernel,
         Schema $schema,
         ScopeValidationRule $scopeValidationRule,
     ) {
-        $this->types = $types;
         $this->kernel = $kernel;
         $this->schema = $schema;
         $this->scopeValidationRule = $scopeValidationRule;
@@ -62,7 +55,7 @@ class ApiController extends AbstractController
 
     #[Route(path: '/api', name: 'api', methods: ['GET', 'POST'])]
     #[IsGranted(new Expression("is_granted('ROLE_OAUTH2_READ') or is_granted('ROLE_OAUTH2_WRITE')"))]
-    public function index(Request $request)
+    public function index(Request $request): JsonResponse
     {
         switch ($request->getMethod()) {
             case 'GET':

--- a/DependencyInjection/ApiExtension.php
+++ b/DependencyInjection/ApiExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 class ApiExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $extensionConfigsRefl = new \ReflectionProperty(ContainerBuilder::class, 'extensionConfigs');
         $extensionConfigsRefl->setAccessible(true);

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -31,7 +31,7 @@ class ApiCompilerPass implements CompilerPassInterface
     private const RSA_KEY_PATTERN =
         '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----)\R.*(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)\R?$/s';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->configureTrigger($container);
         $this->configureAllowList($container);
@@ -47,7 +47,7 @@ class ApiCompilerPass implements CompilerPassInterface
         }
     }
 
-    private function configureSchema(ContainerBuilder $container)
+    private function configureSchema(ContainerBuilder $container): void
     {
         $queriesServiceDef = $container->getDefinition('api.queries');
         $mutationsServiceDef = $container->getDefinition('api.mutations');
@@ -64,7 +64,7 @@ class ApiCompilerPass implements CompilerPassInterface
         }
     }
 
-    private function configureTrigger(ContainerBuilder $container)
+    private function configureTrigger(ContainerBuilder $container): void
     {
         $serviceDef = $container->getDefinition(WebHookEvents::class);
         foreach ($container->getDefinitions() as $definition) {
@@ -93,7 +93,7 @@ class ApiCompilerPass implements CompilerPassInterface
         return $reflection !== null && $reflection->isInstantiable();
     }
 
-    private function configureAllowList(ContainerBuilder $container)
+    private function configureAllowList(ContainerBuilder $container): void
     {
         $ids = $container->findTaggedServiceIds('eccube.api.allow_list');
         $typesDef = $container->getDefinition(Types::class);
@@ -104,7 +104,7 @@ class ApiCompilerPass implements CompilerPassInterface
         }
     }
 
-    private function configureKeyPair(ContainerBuilder $container)
+    private function configureKeyPair(ContainerBuilder $container): void
     {
         $projectDir = $container->getParameter('kernel.project_dir');
         $oauthConfig = $container->getExtensionConfig('league_oauth2_server');
@@ -118,12 +118,12 @@ class ApiCompilerPass implements CompilerPassInterface
         }
     }
 
-    private function isRSAKeyContent($string)
+    private function isRSAKeyContent(string $string): int|false
     {
         return preg_match(self::RSA_KEY_PATTERN, $string);
     }
 
-    private function generateKeys($privateKeyPath, $publicKeyPath)
+    private function generateKeys(string $privateKeyPath, string $publicKeyPath): void
     {
         if (false === function_exists('openssl_pkey_new')) {
             throw new \RuntimeException('OpenSSL extension not available');
@@ -147,12 +147,12 @@ class ApiCompilerPass implements CompilerPassInterface
         }
 
         if (false === file_put_contents($privateKeyPath, $privateKey)) {
-            throw new \RuntimeException('File "%s" was not created', $privateKeyPath);
+            throw new \RuntimeException(sprintf('File "%s" was not created', $privateKeyPath));
         }
         chmod($privateKeyPath, 0600);
 
         if (false === file_put_contents($publicKeyPath, $publicKey)) {
-            throw new \RuntimeException('File "%s" was not created', $publicKeyPath);
+            throw new \RuntimeException(sprintf('File "%s" was not created', $publicKeyPath));
         }
         chmod($publicKeyPath, 0644);
     }

--- a/Doctrine/EventSubscriber/EntityListener.php
+++ b/Doctrine/EventSubscriber/EntityListener.php
@@ -14,8 +14,10 @@
 namespace Plugin\Api44\Doctrine\EventSubscriber;
 
 use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\PostPersistEventArgs;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PreRemoveEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Plugin\Api44\Service\WebHookEvents;
 
 class EntityListener implements EventSubscriber
@@ -35,7 +37,10 @@ class EntityListener implements EventSubscriber
         $this->webHookEvents = $webHookEvents;
     }
 
-    public function getSubscribedEvents()
+    /**
+     * @return array<int, string>
+     */
+    public function getSubscribedEvents(): array
     {
         return [
             Events::postPersist,
@@ -44,17 +49,17 @@ class EntityListener implements EventSubscriber
         ];
     }
 
-    public function postPersist(LifecycleEventArgs $args)
+    public function postPersist(PostPersistEventArgs $args): void
     {
         $this->webHookEvents->onCreated($args->getObject());
     }
 
-    public function postUpdate(LifecycleEventArgs $args)
+    public function postUpdate(PostUpdateEventArgs $args): void
     {
         $this->webHookEvents->onUpdated($args->getObject());
     }
 
-    public function preRemove(LifecycleEventArgs $args)
+    public function preRemove(PreRemoveEventArgs $args): void
     {
         $this->webHookEvents->onDeleted($args->getObject());
     }

--- a/Entity/WebHook.php
+++ b/Entity/WebHook.php
@@ -14,6 +14,8 @@
 namespace Plugin\Api44\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Eccube\Entity\AbstractEntity;
+use Plugin\Api44\Repository\WebHookRepository;
 
 /**
  * Class WebHook
@@ -22,8 +24,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\InheritanceType('SINGLE_TABLE')]
 #[ORM\DiscriminatorColumn(name: 'discriminator_type', type: 'string', length: 255)]
 #[ORM\HasLifecycleCallbacks]
-#[ORM\Entity(repositoryClass: \Plugin\Api44\Repository\WebHookRepository::class)]
-class WebHook
+#[ORM\Entity(repositoryClass: WebHookRepository::class)]
+class WebHook extends AbstractEntity
 {
     /**
      * @var int ID
@@ -31,19 +33,19 @@ class WebHook
     #[ORM\Column(name: 'id', type: 'integer', options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
+    private int $id = 0;
 
     /**
      * @var string Payload URL
      */
     #[ORM\Column(name: 'payload_url', type: 'string', length: 1024)]
-    private $payloadUrl;
+    private string $payloadUrl;
 
     /**
      * @var string|null Secret
      */
     #[ORM\Column(name: 'secret', type: 'string', length: 1024, nullable: true)]
-    private $secret;
+    private ?string $secret = null;
 
     /**
      * @var bool Whether this WebHook is enabled.
@@ -55,13 +57,13 @@ class WebHook
      * @var \DateTime
      */
     #[ORM\Column(name: 'create_date', type: 'datetimetz')]
-    private $createDate;
+    private \DateTime $createDate;
 
     /**
      * @var \DateTime
      */
     #[ORM\Column(name: 'update_date', type: 'datetimetz')]
-    private $updateDate;
+    private \DateTime $updateDate;
 
     /**
      * @return int
@@ -74,7 +76,7 @@ class WebHook
     /**
      * @param int $id
      */
-    public function setId(int $id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -90,7 +92,7 @@ class WebHook
     /**
      * @param string $payloadUrl
      */
-    public function setPayloadUrl(string $payloadUrl)
+    public function setPayloadUrl(string $payloadUrl): void
     {
         $this->payloadUrl = $payloadUrl;
     }
@@ -106,7 +108,7 @@ class WebHook
     /**
      * @param string|null $secret
      */
-    public function setSecret(?string $secret)
+    public function setSecret(?string $secret): void
     {
         $this->secret = $secret;
     }
@@ -122,7 +124,7 @@ class WebHook
     /**
      * @param bool $enabled
      */
-    public function setEnabled(bool $enabled)
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
@@ -138,7 +140,7 @@ class WebHook
     /**
      * @param \DateTime $createDate
      */
-    public function setCreateDate(\DateTime $createDate)
+    public function setCreateDate(\DateTime $createDate): void
     {
         $this->createDate = $createDate;
     }
@@ -154,7 +156,7 @@ class WebHook
     /**
      * @param \DateTime $updateDate
      */
-    public function setUpdateDate(\DateTime $updateDate)
+    public function setUpdateDate(\DateTime $updateDate): void
     {
         $this->updateDate = $updateDate;
     }

--- a/Entity/WebHook.php
+++ b/Entity/WebHook.php
@@ -28,12 +28,12 @@ use Plugin\Api44\Repository\WebHookRepository;
 class WebHook extends AbstractEntity
 {
     /**
-     * @var int ID
+     * @var int|null ID
      */
     #[ORM\Column(name: 'id', type: 'integer', options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private int $id = 0;
+    private ?int $id = null;
 
     /**
      * @var string Payload URL
@@ -66,9 +66,9 @@ class WebHook extends AbstractEntity
     private \DateTime $updateDate;
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/EventListener/AuthorizationRequestResolveListener.php
+++ b/EventListener/AuthorizationRequestResolveListener.php
@@ -20,6 +20,7 @@ use League\Bundle\OAuth2ServerBundle\OAuth2Events;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Plugin\Api44\Form\Type\Admin\OAuth2AuthorizationType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\ClickableInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -46,6 +47,9 @@ final class AuthorizationRequestResolveListener implements EventSubscriberInterf
         $this->requestStack = $requestStack;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -91,7 +95,8 @@ final class AuthorizationRequestResolveListener implements EventSubscriberInterf
             if ('POST' === $request->getMethod()) {
                 $form->handleRequest($request);
                 if ($form->isSubmitted() && $form->isValid()) {
-                    if ($form->get('approve')->isClicked()) {
+                    $approveButton = $form->get('approve');
+                    if ($approveButton instanceof ClickableInterface && $approveButton->isClicked()) {
                         $event->resolveAuthorization(AuthorizationRequestResolveEvent::AUTHORIZATION_APPROVED);
                     }
                 } else {

--- a/EventListener/UserResolveListener.php
+++ b/EventListener/UserResolveListener.php
@@ -16,12 +16,13 @@ namespace Plugin\Api44\EventListener;
 use League\Bundle\OAuth2ServerBundle\Event\UserResolveEvent;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 final class UserResolveListener
 {
     /**
-     * @var UserProviderInterface
+     * @var UserProviderInterface<\Symfony\Component\Security\Core\User\UserInterface>
      */
     private UserProviderInterface $userProvider;
 
@@ -31,7 +32,7 @@ final class UserResolveListener
     private UserPasswordHasherInterface $userPasswordHasher;
 
     /**
-     * @param UserProviderInterface $userProvider
+     * @param UserProviderInterface<\Symfony\Component\Security\Core\User\UserInterface> $userProvider
      * @param UserPasswordHasherInterface $userPasswordHasher
      */
     public function __construct(UserProviderInterface $userProvider, UserPasswordHasherInterface $userPasswordHasher)
@@ -48,6 +49,10 @@ final class UserResolveListener
         try {
             $user = $this->userProvider->loadUserByIdentifier($event->getUsername());
         } catch (UserNotFoundException $e) {
+            return;
+        }
+
+        if (!$user instanceof PasswordAuthenticatedUserInterface) {
             return;
         }
 

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -44,7 +44,7 @@ class ClientType extends AbstractType
      *
      * @throws \Exception
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('identifier', TextType::class, [

--- a/Form/Type/Admin/OAuth2AuthorizationType.php
+++ b/Form/Type/Admin/OAuth2AuthorizationType.php
@@ -35,7 +35,7 @@ class OAuth2AuthorizationType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         // TODO
         $builder

--- a/Form/Type/Admin/WebHookType.php
+++ b/Form/Type/Admin/WebHookType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class WebHookType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('payload_url', UrlType::class, [

--- a/GraphQL/AllowList.php
+++ b/GraphQL/AllowList.php
@@ -15,19 +15,22 @@ namespace Plugin\Api44\GraphQL;
 
 class AllowList
 {
-    private $allows;
+    /**
+     * @var array<string, list<string>>
+     */
+    private array $allows;
 
     /**
      * AllowList constructor.
      *
-     * @param $allows
+     * @param array<string, list<string>> $allows
      */
-    public function __construct($allows)
+    public function __construct(array $allows)
     {
         $this->allows = $allows;
     }
 
-    public function isAllowed($entityName, $propertyName)
+    public function isAllowed(string $entityName, string $propertyName): bool
     {
         $allowProperties = $this->allows[$entityName] ?? [];
 

--- a/GraphQL/Mutation.php
+++ b/GraphQL/Mutation.php
@@ -21,7 +21,7 @@ interface Mutation
     public function getName(): string;
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function getMutation(): array;
 }

--- a/GraphQL/Mutation/UpdateProductStockMutation.php
+++ b/GraphQL/Mutation/UpdateProductStockMutation.php
@@ -16,9 +16,6 @@ namespace Plugin\Api44\GraphQL\Mutation;
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation;
@@ -57,7 +54,7 @@ class UpdateProductStockMutation implements Mutation
     }
 
     /**
-     * @return array<string, ObjectType|array<string, array<string, NonNull|ScalarType|string>>|$this[]|string[]>
+     * @return array<string, mixed>
      */
     public function getMutation(): array
     {

--- a/GraphQL/Mutation/UpdateProductStockMutation.php
+++ b/GraphQL/Mutation/UpdateProductStockMutation.php
@@ -16,6 +16,9 @@ namespace Plugin\Api44\GraphQL\Mutation;
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation;
@@ -53,6 +56,9 @@ class UpdateProductStockMutation implements Mutation
         return 'updateProductStock';
     }
 
+    /**
+     * @return array<string, ObjectType|array<string, array<string, NonNull|ScalarType|string>>|$this[]|string[]>
+     */
     public function getMutation(): array
     {
         return [
@@ -75,7 +81,11 @@ class UpdateProductStockMutation implements Mutation
         ];
     }
 
-    public function updateProductStock($root, $args)
+    /**
+     * @param mixed $root
+     * @param array<string, mixed> $args
+     */
+    public function updateProductStock(mixed $root, array $args): ProductClass
     {
         $ProductClasses = $this->productClassRepository->findBy(['code' => $args['code']]);
 

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -22,6 +22,9 @@ use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\ShippingRepository;
 use Eccube\Service\MailService;
 use Eccube\Service\OrderStateMachine;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation;
@@ -92,6 +95,9 @@ class UpdateShippedMutation implements Mutation
         return 'updateShipped';
     }
 
+    /**
+     * @return array<string, ObjectType|array<string, array<string, bool|NonNull|ScalarType|string>>|$this[]|string[]>
+     */
     public function getMutation(): array
     {
         return [
@@ -127,7 +133,11 @@ class UpdateShippedMutation implements Mutation
         ];
     }
 
-    public function updateShipped($root, $args)
+    /**
+     * @param mixed $root
+     * @param array<string, mixed> $args
+     */
+    public function updateShipped(mixed $root, array $args): Shipping
     {
         // XXX Validate with string
         if (array_key_exists('shipping_date', $args) && $args['shipping_date'] instanceof \DateTime) {
@@ -162,6 +172,8 @@ class UpdateShippedMutation implements Mutation
     /**
      * 引数の検証
      *
+     * @param array<string, mixed> $args
+     *
      * @throws InvalidArgumentException
      */
     private function validateArgs(array $args): void
@@ -182,8 +194,8 @@ class UpdateShippedMutation implements Mutation
 
     private function getConstraint(): Constraint
     {
-        return new Assert\Collection([
-            'fields' => [
+        return new Assert\Collection(
+            fields: [
                 'id' => new Assert\GreaterThan(0),
                 'shipping_date' => new Assert\DateTime('Y-m-d\TH:i:sP'),
                 'shipping_delivery_name' => new Assert\Length([
@@ -197,8 +209,8 @@ class UpdateShippedMutation implements Mutation
                 ]),
                 'is_send_mail' => new Assert\Choice([true, false]),
             ],
-            'allowMissingFields' => true,
-        ]);
+            allowMissingFields: true,
+        );
     }
 
     /**
@@ -229,6 +241,8 @@ class UpdateShippedMutation implements Mutation
 
     /**
      * args で Shipping の出荷済み処理
+     *
+     * @param array<string, mixed> $args
      */
     private function updateShippingShippedWithArgs(Shipping $Shipping, array $args): void
     {
@@ -261,7 +275,7 @@ class UpdateShippedMutation implements Mutation
     private function updateOrderShipped(Order $Order): void
     {
         // Order に紐づく全ての Shipping が出荷済みか
-        $allShipped = array_reduce($Order->getShippings()->toArray(), function ($carry, $Shipping) {
+        $allShipped = array_reduce($Order->getShippings()->toArray(), function (bool $carry, Shipping $Shipping): bool {
             return $carry && $Shipping->isShipped();
         }, true);
 

--- a/GraphQL/Mutation/UpdateShippedMutation.php
+++ b/GraphQL/Mutation/UpdateShippedMutation.php
@@ -22,9 +22,6 @@ use Eccube\Repository\Master\OrderStatusRepository;
 use Eccube\Repository\ShippingRepository;
 use Eccube\Service\MailService;
 use Eccube\Service\OrderStateMachine;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation;
@@ -96,7 +93,7 @@ class UpdateShippedMutation implements Mutation
     }
 
     /**
-     * @return array<string, ObjectType|array<string, array<string, bool|NonNull|ScalarType|string>>|$this[]|string[]>
+     * @return array<string, mixed>
      */
     public function getMutation(): array
     {

--- a/GraphQL/Query.php
+++ b/GraphQL/Query.php
@@ -21,7 +21,7 @@ interface Query
     public function getName(): string;
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function getQuery(): array;
 }

--- a/GraphQL/Query/CustomersQuery.php
+++ b/GraphQL/Query/CustomersQuery.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\Api44\GraphQL\Query;
 
+use Doctrine\ORM\QueryBuilder;
 use Eccube\Entity\Customer;
 use Eccube\Form\Type\Admin\SearchCustomerType;
 use Eccube\Repository\CustomerRepository;
@@ -39,9 +40,12 @@ class CustomersQuery extends SearchFormQuery
         return 'customers';
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getQuery(): array
     {
-        return $this->createQuery(Customer::class, SearchCustomerType::class, function ($searchData) {
+        return $this->createQuery(Customer::class, SearchCustomerType::class, function (array $searchData): QueryBuilder {
             return $this->customerRepository->getQueryBuilderBySearchData($searchData);
         });
     }

--- a/GraphQL/Query/OrdersQuery.php
+++ b/GraphQL/Query/OrdersQuery.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\Api44\GraphQL\Query;
 
+use Doctrine\ORM\QueryBuilder;
 use Eccube\Entity\Order;
 use Eccube\Form\Type\Admin\SearchOrderType;
 use Eccube\Repository\OrderRepository;
@@ -39,9 +40,12 @@ class OrdersQuery extends SearchFormQuery
         return 'orders';
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getQuery(): array
     {
-        return $this->createQuery(Order::class, SearchOrderType::class, function ($searchData) {
+        return $this->createQuery(Order::class, SearchOrderType::class, function (array $searchData): QueryBuilder {
             return $this->orderRepository->getQueryBuilderBySearchDataForAdmin($searchData);
         });
     }

--- a/GraphQL/Query/ProductsQuery.php
+++ b/GraphQL/Query/ProductsQuery.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\Api44\GraphQL\Query;
 
+use Doctrine\ORM\QueryBuilder;
 use Eccube\Entity\Product;
 use Eccube\Form\Type\Admin\SearchProductType;
 use Eccube\Repository\ProductRepository;
@@ -39,9 +40,12 @@ class ProductsQuery extends SearchFormQuery
         return 'products';
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getQuery(): array
     {
-        return $this->createQuery(Product::class, SearchProductType::class, function ($searchData) {
+        return $this->createQuery(Product::class, SearchProductType::class, function (array $searchData): QueryBuilder {
             return $this->productRepository->getQueryBuilderBySearchDataForAdmin($searchData);
         });
     }

--- a/GraphQL/Query/SearchFormQuery.php
+++ b/GraphQL/Query/SearchFormQuery.php
@@ -16,6 +16,7 @@ namespace Plugin\Api44\GraphQL\Query;
 use Eccube\Common\EccubeConfig;
 use Eccube\Util\StringUtil;
 use GraphQL\Type\Definition\Type;
+use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\PaginatorInterface;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Query;
@@ -75,13 +76,18 @@ abstract class SearchFormQuery implements Query
         $this->types = $types;
     }
 
-    protected function createQuery($entityClass, $searchFormType, $resolver)
+    /**
+     * @param class-string $entityClass
+     *
+     * @return array<string, mixed>
+     */
+    protected function createQuery(string $entityClass, string $searchFormType, callable $resolver): array
     {
         $builder = $this->formFactory->createBuilder($searchFormType, null, ['csrf_protection' => false]);
         $this->overrideDateTimeFormat($builder);
         $this->addPagingForms($builder);
 
-        $args = array_reduce($builder->getForm()->all(), function ($acc, $form) {
+        $args = array_reduce($builder->getForm()->all(), function (array $acc, FormInterface $form): array {
             /* @var FormInterface $form */
             $formConfig = $form->getConfig();
             $typeClass = get_class($formConfig->getType()->getInnerType());
@@ -115,7 +121,7 @@ abstract class SearchFormQuery implements Query
         return [
             'type' => new ConnectionType($entityClass, $this->types),
             'args' => $args,
-            'resolve' => function ($root, $args) use ($builder, $resolver) {
+            'resolve' => function ($root, string|array|null $args) use ($builder, $resolver): PaginationInterface {
                 $form = $builder->getForm();
 
                 foreach ($form->all() as $field) {
@@ -151,7 +157,7 @@ abstract class SearchFormQuery implements Query
      *
      * @param FormBuilderInterface $builder
      */
-    private function overrideDateTimeFormat(FormBuilderInterface $builder)
+    private function overrideDateTimeFormat(FormBuilderInterface $builder): void
     {
         /** @var FormBuilderInterface $field */
         foreach ($builder->all() as $field) {
@@ -170,7 +176,7 @@ abstract class SearchFormQuery implements Query
      *
      * @param FormBuilderInterface $builder
      */
-    private function addPagingForms(FormBuilderInterface $builder)
+    private function addPagingForms(FormBuilderInterface $builder): void
     {
         $builder->add('page', IntegerType::class, [
             'label' => 'api.search_form_query.args.description.page',

--- a/GraphQL/Query/SearchFormQuery.php
+++ b/GraphQL/Query/SearchFormQuery.php
@@ -121,7 +121,7 @@ abstract class SearchFormQuery implements Query
         return [
             'type' => new ConnectionType($entityClass, $this->types),
             'args' => $args,
-            'resolve' => function ($root, string|array|null $args) use ($builder, $resolver): PaginationInterface {
+            'resolve' => function ($root, array $args) use ($builder, $resolver): PaginationInterface {
                 $form = $builder->getForm();
 
                 foreach ($form->all() as $field) {

--- a/GraphQL/Query/SingleResultQuery.php
+++ b/GraphQL/Query/SingleResultQuery.php
@@ -13,7 +13,6 @@
 
 namespace Plugin\Api44\GraphQL\Query;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Query;
@@ -33,9 +32,9 @@ abstract class SingleResultQuery implements Query
     private Types $types;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
-    private EntityManager $entityManager;
+    private EntityManagerInterface $entityManager;
 
     /**
      * SingleResultQuery constructor.
@@ -51,7 +50,7 @@ abstract class SingleResultQuery implements Query
      * @param EntityManagerInterface $entityManager
      */
     #[Required]
-    public function setEntityManager(EntityManagerInterface $entityManager)
+    public function setEntityManager(EntityManagerInterface $entityManager): void
     {
         $this->entityManager = $entityManager;
     }
@@ -65,6 +64,9 @@ abstract class SingleResultQuery implements Query
         $this->types = $types;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getQuery(): array
     {
         return [
@@ -72,7 +74,7 @@ abstract class SingleResultQuery implements Query
             'args' => [
                 'id' => Type::nonNull(Type::id()),
             ],
-            'resolve' => function ($root, $args) {
+            'resolve' => function ($root, array $args): ?object {
                 return $this->entityManager->getRepository($this->entityClass)->find($args['id']);
             },
         ];

--- a/GraphQL/Schema.php
+++ b/GraphQL/Schema.php
@@ -17,6 +17,10 @@ use GraphQL\Type\Definition\ObjectType;
 
 class Schema extends \GraphQL\Type\Schema
 {
+    /**
+     * @param \ArrayObject<int, Query> $queries
+     * @param \ArrayObject<int, Mutation> $mutations
+     */
     public function __construct(
         Types $types,
         \ArrayObject $queries,
@@ -25,23 +29,23 @@ class Schema extends \GraphQL\Type\Schema
         parent::__construct([
             'query' => new ObjectType([
                 'name' => 'Query',
-                'fields' => array_reduce($queries->getArrayCopy(), function ($acc, Query $query) {
+                'fields' => array_reduce($queries->getArrayCopy(), function (array $acc, Query $query): array {
                     $acc[$query->getName()] = $query->getQuery();
 
                     return $acc;
                 }, []),
-                'typeLoader' => function ($name) use ($types) {
+                'typeLoader' => function ($name) use ($types): ObjectType {
                     return $types->get($name);
                 },
             ]),
             'mutation' => new ObjectType([
                 'name' => 'Mutation',
-                'fields' => array_reduce($mutations->getArrayCopy(), function ($acc, Mutation $mutation) {
+                'fields' => array_reduce($mutations->getArrayCopy(), function (array $acc, Mutation $mutation): array {
                     $acc[$mutation->getName()] = $mutation->getMutation();
 
                     return $acc;
                 }, []),
-                'typeLoader' => function ($name) use ($types) {
+                'typeLoader' => function ($name) use ($types): ObjectType {
                     return $types->get($name);
                 },
             ]),

--- a/GraphQL/ScopeValidationRule.php
+++ b/GraphQL/ScopeValidationRule.php
@@ -14,6 +14,7 @@
 namespace Plugin\Api44\GraphQL;
 
 use GraphQL\Error\Error;
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Validator\QueryValidationContext;
@@ -35,10 +36,16 @@ class ScopeValidationRule extends ValidationRule
         $this->authorizationChecker = $authorizationChecker;
     }
 
+    /**
+     * @return array<string, callable(Node): void>
+     */
     public function getVisitor(QueryValidationContext $context): array
     {
         return [
-            NodeKind::OPERATION_DEFINITION => function (OperationDefinitionNode $def) use ($context) {
+            NodeKind::OPERATION_DEFINITION => function (Node $def) use ($context): void {
+                if (!$def instanceof OperationDefinitionNode) {
+                    return;
+                }
                 if ($def->operation === 'query' && !$this->authorizationChecker->isGranted('ROLE_OAUTH2_READ')) {
                     $context->reportError(new Error('Insufficient permission. (read)'));
                 } elseif ($def->operation === 'mutation'

--- a/GraphQL/Type/ConnectionType.php
+++ b/GraphQL/Type/ConnectionType.php
@@ -45,7 +45,7 @@ class ConnectionType extends ObjectType
                 ],
                 'totalCount' => [
                     'type' => Type::nonNull(Type::int()),
-                    'resolve' => function (PaginationInterface $pagination) {
+                    'resolve' => function (PaginationInterface $pagination): int {
                         return $pagination->getTotalItemCount();
                     },
                 ],

--- a/GraphQL/Type/Definition/DateTimeType.php
+++ b/GraphQL/Type/Definition/DateTimeType.php
@@ -22,7 +22,7 @@ use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 
 class DateTimeType extends ScalarType
 {
-    private static $DateTimeType;
+    private static ?DateTimeType $DateTimeType = null;
 
     public function __construct()
     {
@@ -64,7 +64,7 @@ class DateTimeType extends ScalarType
 
     /**
      * @param Node $valueNode
-     * @param array|null $variables
+     * @param array<string, mixed>|null $variables
      *
      * @return \DateTime|null
      */
@@ -82,10 +82,10 @@ class DateTimeType extends ScalarType
      */
     public static function dateTime(): ScalarType
     {
-        if (static::$DateTimeType === null) {
-            static::$DateTimeType = new DateTimeType();
+        if (self::$DateTimeType === null) {
+            self::$DateTimeType = new self();
         }
 
-        return static::$DateTimeType;
+        return self::$DateTimeType;
     }
 }

--- a/GraphQL/Type/PageInfoType.php
+++ b/GraphQL/Type/PageInfoType.php
@@ -15,7 +15,7 @@ namespace Plugin\Api44\GraphQL\Type;
 
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-use Knp\Component\Pager\Pagination\PaginationInterface;
+use Knp\Bundle\PaginatorBundle\Pagination\SlidingPaginationInterface;
 
 class PageInfoType extends ObjectType
 {
@@ -23,17 +23,17 @@ class PageInfoType extends ObjectType
     {
         $config = [
             'name' => (new \ReflectionClass($className))->getShortName().'PageInfo',
-            'fields' => function () {
+            'fields' => function (): array {
                 return [
                     'hasNextPage' => [
                         'type' => Type::nonNull(Type::boolean()),
-                        'resolve' => function (PaginationInterface $pagination) {
+                        'resolve' => function (SlidingPaginationInterface $pagination): bool {
                             return isset($pagination->getPaginationData()['next']);
                         },
                     ],
                     'hasPreviousPage' => [
                         'type' => Type::nonNull(Type::boolean()),
-                        'resolve' => function (PaginationInterface $pagination) {
+                        'resolve' => function (SlidingPaginationInterface $pagination): bool {
                             return isset($pagination->getPaginationData()['previous']);
                         },
                     ],

--- a/GraphQL/Types.php
+++ b/GraphQL/Types.php
@@ -15,7 +15,17 @@ namespace Plugin\Api44\GraphQL;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Mapping\ManyToManyInverseSideMapping;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
+use Doctrine\ORM\Mapping\OneToOneInverseSideMapping;
+use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Plugin\Api44\GraphQL\Type\Definition\DateTimeType;
 
@@ -27,9 +37,15 @@ class Types
     /** @var EntityManager */
     private EntityManager $entityManager;
 
-    private $types = [];
+    /**
+     * @var array<string, ObjectType>
+     */
+    private array $types = [];
 
-    private $allowLists = [];
+    /**
+     * @var AllowList[]
+     */
+    private array $allowLists = [];
 
     /**
      * Types constructor.
@@ -39,7 +55,7 @@ class Types
         $this->entityManager = $entityManager;
     }
 
-    public function addAllowList(AllowList $allowList)
+    public function addAllowList(AllowList $allowList): void
     {
         $this->allowLists[] = $allowList;
     }
@@ -47,11 +63,9 @@ class Types
     /**
      * Entityに対応するObjectTypeを返す.
      *
-     * @param $className string Entityクラス名
-     *
-     * @return ObjectType
+     * @param class-string $className Entityクラス名
      */
-    public function get($className): ObjectType
+    public function get(string $className): ObjectType
     {
         if (!isset($this->types[$className])) {
             $this->types[$className] = $this->createObjectType($className);
@@ -60,17 +74,20 @@ class Types
         return $this->types[$className];
     }
 
-    private function createObjectType($className)
+    /**
+     * @param class-string $className
+     */
+    private function createObjectType(string $className): ObjectType
     {
         return new ObjectType([
             'name' => (new \ReflectionClass($className))->getShortName(),
             'fields' => function () use ($className) {
                 $classMetadata = $this->entityManager->getClassMetadata($className);
-                $fields = array_reduce($classMetadata->fieldMappings, function ($acc, $mapping) use ($classMetadata) {
+                $fields = array_reduce($classMetadata->fieldMappings, function (array $acc, FieldMapping $mapping) use ($classMetadata): array {
                     $type = $this->convertFieldMappingToType($mapping);
                     $fieldName = $mapping['fieldName'];
 
-                    $allowed = array_filter($this->allowLists, function (AllowList $al) use ($classMetadata, $fieldName) {
+                    $allowed = array_filter($this->allowLists, function (AllowList $al) use ($classMetadata, $fieldName): bool {
                         return $al->isAllowed($classMetadata->name, $fieldName);
                     });
 
@@ -81,10 +98,10 @@ class Types
                     return $acc;
                 }, []);
 
-                $fields = array_reduce($classMetadata->associationMappings, function ($acc, $mapping) use ($classMetadata) {
+                $fields = array_reduce($classMetadata->associationMappings, function (array $acc, ManyToManyInverseSideMapping|ManyToManyOwningSideMapping|ManyToOneAssociationMapping|OneToManyAssociationMapping|OneToOneInverseSideMapping|OneToOneOwningSideMapping $mapping) use ($classMetadata): array {
                     $fieldName = $mapping['fieldName'];
 
-                    $allowed = array_filter($this->allowLists, function (AllowList $al) use ($classMetadata, $fieldName) {
+                    $allowed = array_filter($this->allowLists, function (AllowList $al) use ($classMetadata, $fieldName): bool {
                         return $al->isAllowed($classMetadata->name, $fieldName);
                     });
 
@@ -102,31 +119,39 @@ class Types
         ]);
     }
 
-    private function convertFieldMappingToType($fieldMapping)
+    private function convertFieldMappingToType(FieldMapping $fieldMapping): ScalarType|NonNull|null
     {
-        $type = isset($fieldMapping['id']) ? Type::id() : [
-            'string' => Type::string(),
-            'text' => Type::string(),
-            'integer' => Type::int(),
-            'decimal' => Type::float(),
-            'datetimetz' => DateTimeType::dateTime(),
-            'smallint' => Type::int(),
-            'boolean' => Type::boolean(),
-        ][$fieldMapping['type']];
-
-        if ($type) {
-            return $fieldMapping['nullable'] ? $type : Type::nonNull($type);
+        if (isset($fieldMapping['id'])) {
+            $type = Type::id();
+        } else {
+            // マッピングに無い Doctrine 型 (date / bigint / json 等) は null になり得る
+            $type = [
+                'string' => Type::string(),
+                'text' => Type::string(),
+                'integer' => Type::int(),
+                'decimal' => Type::float(),
+                'datetimetz' => DateTimeType::dateTime(),
+                'smallint' => Type::int(),
+                'boolean' => Type::boolean(),
+            ][$fieldMapping['type']] ?? null;
         }
 
-        return null;
+        if ($type === null) {
+            return null;
+        }
+
+        return $fieldMapping['nullable'] ? $type : Type::nonNull($type);
     }
 
-    private function convertAssociationMappingToType($mapping)
+    /**
+     * @return ListOfType<ObjectType>|ObjectType
+     */
+    private function convertAssociationMappingToType(ManyToManyInverseSideMapping|ManyToManyOwningSideMapping|ManyToOneAssociationMapping|OneToManyAssociationMapping|OneToOneInverseSideMapping|OneToOneOwningSideMapping $mapping): ListOfType|ObjectType
     {
         return $this->isToManyAssociation($mapping) ? Type::listOf($this->get($mapping['targetEntity'])) : $this->get($mapping['targetEntity']);
     }
 
-    private function isToManyAssociation(AssociationMapping $mapping)
+    private function isToManyAssociation(AssociationMapping $mapping): bool
     {
         return $mapping->isToMany();
     }

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -22,7 +22,7 @@ use Psr\Container\ContainerInterface;
 
 class PluginManager extends AbstractPluginManager
 {
-    private $denyUrl = '/api';
+    private string $denyUrl = '/api';
 
     /**
      * {@inheritdoc}
@@ -40,7 +40,7 @@ class PluginManager extends AbstractPluginManager
         $this->removeAuthorityRole($container);
     }
 
-    private function createAuthorityRole(ContainerInterface $container)
+    private function createAuthorityRole(ContainerInterface $container): void
     {
         /** @var EntityManager $entityManager */
         $entityManager = $container->get('doctrine')->getManager();
@@ -56,7 +56,7 @@ class PluginManager extends AbstractPluginManager
         $entityManager->flush();
     }
 
-    private function removeAuthorityRole(ContainerInterface $container)
+    private function removeAuthorityRole(ContainerInterface $container): void
     {
         /** @var EntityManager $entityManager */
         $entityManager = $container->get('doctrine')->getManager();

--- a/Repository/WebHookRepository.php
+++ b/Repository/WebHookRepository.php
@@ -22,7 +22,7 @@ use Plugin\Api44\Entity\WebHook;
  */
 class WebHookRepository extends AbstractRepository
 {
-    public function __construct(ManagerRegistry $registry, $entityClass = WebHook::class)
+    public function __construct(ManagerRegistry $registry, string $entityClass = WebHook::class)
     {
         parent::__construct($registry, $entityClass);
     }

--- a/Service/CoreEntityTrigger.php
+++ b/Service/CoreEntityTrigger.php
@@ -31,11 +31,9 @@ use Eccube\Entity\TaxRule;
 class CoreEntityTrigger implements WebHookTrigger
 {
     /**
-     * @param $entity
-     *
      * @return Customer|Order|Product|null
      */
-    public function emitFor($entity): Customer|Order|Product|null
+    public function emitFor(object $entity): Customer|Order|Product|null
     {
         // Product
         if ($entity instanceof ProductClass) {

--- a/Service/WebHookEvents.php
+++ b/Service/WebHookEvents.php
@@ -19,14 +19,17 @@ use Eccube\Entity\Product;
 
 class WebHookEvents
 {
-    private $events = ['created' => [], 'updated' => [], 'deleted' => []];
+    /**
+     * @var array<string, array<int, array<string, mixed>>>
+     */
+    private array $events = ['created' => [], 'updated' => [], 'deleted' => []];
 
     /**
      * @var WebHookTrigger[]
      */
     private array $triggers = [];
 
-    public function onCreated($entity)
+    public function onCreated(object $entity): void
     {
         if ($this->isTargetEntity($entity)) {
             $this->events['created'][] = $this->toEntityDefinition($entity);
@@ -36,7 +39,7 @@ class WebHookEvents
         }
     }
 
-    public function onUpdated($entity)
+    public function onUpdated(object $entity): void
     {
         if ($this->isTargetEntity($entity)) {
             $this->events['updated'][] = $this->toEntityDefinition($entity);
@@ -46,7 +49,7 @@ class WebHookEvents
         }
     }
 
-    public function onDeleted($entity)
+    public function onDeleted(object $entity): void
     {
         if ($this->isTargetEntity($entity)) {
             $this->events['deleted'][] = $this->toEntityDefinition($entity);
@@ -56,14 +59,17 @@ class WebHookEvents
         }
     }
 
-    private function isTargetEntity($entity)
+    private function isTargetEntity(object $entity): bool
     {
         return $entity instanceof Product
             || $entity instanceof Order
             || $entity instanceof Customer;
     }
 
-    private function toEntityDefinition($entity)
+    /**
+     * @return array<string, mixed>
+     */
+    private function toEntityDefinition(object $entity): array
     {
         return [
             'entity' => strtolower((new \ReflectionClass($entity))->getShortName()),
@@ -71,12 +77,12 @@ class WebHookEvents
         ];
     }
 
-    public function addTrigger(WebHookTrigger $trigger)
+    public function addTrigger(WebHookTrigger $trigger): void
     {
         $this->triggers[] = $trigger;
     }
 
-    private function onAssociationMappingUpdated($entity)
+    private function onAssociationMappingUpdated(object $entity): void
     {
         foreach ($this->triggers as $trigger) {
             $target = $trigger->emitFor($entity);
@@ -86,7 +92,10 @@ class WebHookEvents
         }
     }
 
-    public function toArray()
+    /**
+     * @return mixed[]
+     */
+    public function toArray(): array
     {
         $events = [];
 

--- a/Service/WebHookService.php
+++ b/Service/WebHookService.php
@@ -53,14 +53,17 @@ class WebHookService implements EventSubscriberInterface
         $this->webHookEvents = $webHookEvents;
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'fire',
         ];
     }
 
-    public function fire(ResponseEvent $event)
+    public function fire(ResponseEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;
@@ -86,10 +89,10 @@ class WebHookService implements EventSubscriberInterface
                     'timeout' => 5,
                     'allow_redirects' => false,
                 ],
-                'fulfilled' => function (Response $reason, $index) use ($availableWebHooks) {
+                'fulfilled' => function (Response $reason, $index) use ($availableWebHooks): void {
                     log_info('WebHook request successful.', ['Payload URL' => $availableWebHooks[$index]->getPayloadUrl()]);
                 },
-                'rejected' => function (TransferException $e, $index) use ($availableWebHooks) {
+                'rejected' => function (TransferException $e, $index) use ($availableWebHooks): void {
                     log_error($e->getMessage(), ['Payload URL' => $availableWebHooks[$index]->getPayloadUrl()]);
                 },
             ]);
@@ -98,7 +101,7 @@ class WebHookService implements EventSubscriberInterface
         }
     }
 
-    private function createRequest($payload, $WebHook)
+    private function createRequest(string $payload, WebHook $WebHook): Request
     {
         $headers = [
             'Content-Type' => 'application/json',

--- a/Service/WebHookTrigger.php
+++ b/Service/WebHookTrigger.php
@@ -16,9 +16,7 @@ namespace Plugin\Api44\Service;
 interface WebHookTrigger
 {
     /**
-     * @param $entity
-     *
      * @return mixed|null
      */
-    public function emitFor($entity): mixed;
+    public function emitFor(object $entity): mixed;
 }

--- a/Tests/GraphQL/AllowListTest.php
+++ b/Tests/GraphQL/AllowListTest.php
@@ -15,6 +15,7 @@ namespace Plugin\Api44\Tests\GraphQL;
 
 use Eccube\Entity\Customer;
 use Eccube\Entity\Product;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Plugin\Api44\GraphQL\AllowList;
 
@@ -25,8 +26,8 @@ class AllowListTest extends TestCase
      * @param $propertyName
      * @param $expectAllowed
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('isAllowedWithPropertyNames')]
-    public function testIsAllowedWithPropertyNames($entityClass, $propertyName, $expectAllowed)
+    #[DataProvider('isAllowedWithPropertyNames')]
+    public function testIsAllowedWithPropertyNames(string $entityClass, string $propertyName, bool $expectAllowed): void
     {
         $allowList = new AllowList([
             Customer::class => ['id', 'name'],
@@ -35,7 +36,10 @@ class AllowListTest extends TestCase
         self::assertEquals($expectAllowed, $allowList->isAllowed($entityClass, $propertyName));
     }
 
-    public static function isAllowedWithPropertyNames()
+    /**
+     * @return string[][]|bool[][]
+     */
+    public static function isAllowedWithPropertyNames(): array
     {
         return [
             [Customer::class, 'id', true],

--- a/Tests/GraphQL/AllowListTest.php
+++ b/Tests/GraphQL/AllowListTest.php
@@ -37,7 +37,7 @@ class AllowListTest extends TestCase
     }
 
     /**
-     * @return string[][]|bool[][]
+     * @return list<array{class-string, string, bool}>
      */
     public static function isAllowedWithPropertyNames(): array
     {

--- a/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
@@ -16,6 +16,7 @@ namespace Plugin\Api44\Tests\GraphQL\Mutation;
 use Eccube\Entity\ProductClass;
 use Eccube\Repository\ProductClassRepository;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation\UpdateProductStockMutation;
 use Plugin\Api44\GraphQL\Types;
@@ -37,14 +38,16 @@ class UpdateProductStockMutationTest extends EccubeTestCase
 
         // テスト用の商品を作成
         $Product = $this->createProduct();
-        /** @var ProductClass[] $ProductClasses */
         $ProductClasses = $Product->getProductClasses();
+        self::assertNotNull($ProductClasses);
+        /** @var ProductClass[] $ProductClasses */
+        $ProductClasses = $ProductClasses->toArray();
 
         // 在庫100個
         $ProductClasses[0]->setCode('code-limited');
-        $ProductClasses[0]->setStock(100);
+        $ProductClasses[0]->setStock('100');
         $ProductClasses[0]->setStockUnlimited(false);
-        $ProductClasses[0]->getProductStock()->setStock(100);
+        $ProductClasses[0]->getProductStock()->setStock('100');
 
         // 在庫無制限
         $ProductClasses[1]->setCode('code-unlimited');
@@ -61,9 +64,10 @@ class UpdateProductStockMutationTest extends EccubeTestCase
      * @param $expectStockUnlimited
      * @param $expectStock
      * @param $expectExeption
+     * @param array<string, bool|string|int> $args
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('updateProductStockProvider')]
-    public function testUpdateProductStock($args, $expectStockUnlimited, $expectStock, $expectExeption)
+    #[DataProvider('updateProductStockProvider')]
+    public function testUpdateProductStock(array $args, bool $expectStockUnlimited, ?int $expectStock, ?string $expectExeption): void
     {
         try {
             $ProductClass = $this->updateProductStockMutation->updateProductStock(null, $args);
@@ -84,7 +88,10 @@ class UpdateProductStockMutationTest extends EccubeTestCase
         self::assertEquals($expectStock, $ProductClasses[0]->getProductStock()->getStock());
     }
 
-    public static function updateProductStockProvider()
+    /**
+     * @return array<int, array{array<string, bool|int|string>, bool, int|null, string|null}>
+     */
+    public static function updateProductStockProvider(): array
     {
         return [
             [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => 50], false, 50, null],
@@ -105,7 +112,7 @@ class UpdateProductStockMutationTest extends EccubeTestCase
     /**
      * 重複するcodeを指定して更新
      */
-    public function testUpdateProductStockMultiple()
+    public function testUpdateProductStockMultiple(): void
     {
         // プロダクトコードを重複させる
         $ProductClasses = $this->productClassRepository->findBy(['code' => 'code-limited']);
@@ -117,7 +124,7 @@ class UpdateProductStockMutationTest extends EccubeTestCase
         try {
             $this->updateProductStockMutation->updateProductStock(null, ['code' => 'code-multiple']);
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             self::assertMatchesRegularExpression('/Multiple ProductClass found/', $e->getMessage());
         }
@@ -126,12 +133,12 @@ class UpdateProductStockMutationTest extends EccubeTestCase
     /**
      * 存在しないcodeを指定して更新
      */
-    public function testUpdateProductStockNoData()
+    public function testUpdateProductStockNoData(): void
     {
         try {
             $this->updateProductStockMutation->updateProductStock(null, ['code' => 'code-multiple']);
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             self::assertMatchesRegularExpression('/No ProductClass found/', $e->getMessage());
         }

--- a/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateProductStockMutationTest.php
@@ -60,14 +60,10 @@ class UpdateProductStockMutationTest extends EccubeTestCase
     }
 
     /**
-     * @param $args
-     * @param $expectStockUnlimited
-     * @param $expectStock
-     * @param $expectExeption
      * @param array<string, bool|string|int> $args
      */
     #[DataProvider('updateProductStockProvider')]
-    public function testUpdateProductStock(array $args, bool $expectStockUnlimited, ?int $expectStock, ?string $expectExeption): void
+    public function testUpdateProductStock(array $args, bool $expectStockUnlimited, ?string $expectStock, ?string $expectExeption): void
     {
         try {
             $ProductClass = $this->updateProductStockMutation->updateProductStock(null, $args);
@@ -89,19 +85,19 @@ class UpdateProductStockMutationTest extends EccubeTestCase
     }
 
     /**
-     * @return array<int, array{array<string, bool|int|string>, bool, int|null, string|null}>
+     * @return array<int, array{array<string, bool|int|string>, bool, string|null, string|null}>
      */
     public static function updateProductStockProvider(): array
     {
         return [
-            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => 50], false, 50, null],
-            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => 0], false, 0, null],
-            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => -1], false, 100, '/stock must be a positive integer/'],
-            [['code' => 'code-limited', 'stock_unlimited' => false], false, 100, '/stock is required when stock limited/'],
+            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => 50], false, '50', null],
+            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => 0], false, '0', null],
+            [['code' => 'code-limited', 'stock_unlimited' => false, 'stock' => -1], false, '100', '/stock must be a positive integer/'],
+            [['code' => 'code-limited', 'stock_unlimited' => false], false, '100', '/stock is required when stock limited/'],
             [['code' => 'code-limited', 'stock_unlimited' => true], true, null, null],
-            [['code' => 'code-limited', 'stock_unlimited' => true, 'stock' => 50], false, 100, '/Cannot update stock with stock unlimited/'],
-            [['code' => 'code-unlimited', 'stock_unlimited' => false, 'stock' => 50], false, 50, null],
-            [['code' => 'code-unlimited', 'stock_unlimited' => false, 'stock' => 0], false, 0, null],
+            [['code' => 'code-limited', 'stock_unlimited' => true, 'stock' => 50], false, '100', '/Cannot update stock with stock unlimited/'],
+            [['code' => 'code-unlimited', 'stock_unlimited' => false, 'stock' => 50], false, '50', null],
+            [['code' => 'code-unlimited', 'stock_unlimited' => false, 'stock' => 0], false, '0', null],
             [['code' => 'code-unlimited', 'stock_unlimited' => false, 'stock' => -1], true, null, '/stock must be a positive integer/'],
             [['code' => 'code-unlimited', 'stock_unlimited' => false], true, null, '/stock is required when stock limited/'],
             [['code' => 'code-unlimited', 'stock_unlimited' => true], true, null, null],

--- a/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
@@ -21,6 +21,7 @@ use Eccube\Repository\ShippingRepository;
 use Eccube\Service\MailService;
 use Eccube\Service\OrderStateMachine;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Plugin\Api44\GraphQL\Error\InvalidArgumentException;
 use Plugin\Api44\GraphQL\Mutation\UpdateShippedMutation;
 use Plugin\Api44\GraphQL\Types;
@@ -68,7 +69,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 正常系
      */
-    public function testResponseAndDB()
+    public function testResponseAndDB(): void
     {
         $dateTime = \DateTime::createFromFormat(\DateTime::ATOM, '2020-05-18T12:57:08+09:00');
         $args = [
@@ -90,7 +91,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
             self::assertEquals('notes_0123456789', $Shipping->getNote());
         } catch (InvalidArgumentException $e) {
             // 通らない
-            self::assertTrue(false, $e->getMessage());
+            self::fail($e->getMessage());
         }
 
         // DB の確認
@@ -103,9 +104,11 @@ class UpdateShippedMutationTest extends EccubeTestCase
 
     /**
      * 引数のバリデーションチェック
+     *
+     * @param \DateTime[]|lowercase-string[]|int[]|bool[] $args
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('validateArgsProvider')]
-    public function testValidateArgs($args = [], ?string $message = null)
+    #[DataProvider('validateArgsProvider')]
+    public function testValidateArgs(array $args = [], ?string $message = null): void
     {
         $args = array_merge($args, ['id' => $this->Order->getShippings()->current()->getId()]);
 
@@ -125,7 +128,10 @@ class UpdateShippedMutationTest extends EccubeTestCase
         }
     }
 
-    public static function validateArgsProvider()
+    /**
+     * @return array<int, array{0: array<string, bool|int|string|\DateTime>, 1?: string}>
+     */
+    public static function validateArgsProvider(): array
     {
         // dataProvider 実行時点で eccubeConfig がまだ使えないのでベタがきする。
         $eccube_mtext_len = 200;
@@ -153,14 +159,14 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 対象の出荷情報がない場合
      */
-    public function testNoShippingFound()
+    public function testNoShippingFound(): void
     {
         $args = ['id' => 9999];
 
         try {
             $this->updateShippedMutation->updateShipped(null, $args);
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             // エラーの確認
             self::assertTrue($e->isClientSafe());
@@ -171,7 +177,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 対象の出荷情報がすでに出荷済みの場合
      */
-    public function testAlreadyShipped()
+    public function testAlreadyShipped(): void
     {
         // Shipping を出荷済みに変更
         /** @var Shipping $Shipping */
@@ -184,7 +190,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
         try {
             $this->updateShippedMutation->updateShipped(null, $args);
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             // エラーの確認
             self::assertTrue($e->isClientSafe());
@@ -195,7 +201,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 対象の受注情報が出荷済みにできない受注ステータスだった場合
      */
-    public function testOrderCannotBeShipped()
+    public function testOrderCannotBeShipped(): void
     {
         // 受注をキャンセルに変更
         $OrderStatus = $this->entityManager->getRepository(OrderStatus::class)->find(OrderStatus::CANCEL);
@@ -207,7 +213,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
         try {
             $this->updateShippedMutation->updateShipped(null, $args);
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         } catch (InvalidArgumentException $e) {
             // エラーの確認
             self::assertTrue($e->isClientSafe());
@@ -218,7 +224,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 対象の受注の出荷情報が全て出荷済みになれば受注を出荷済みにする
      */
-    public function testOrderShipped()
+    public function testOrderShipped(): void
     {
         // Orderを新しく作り、Shippingをもう一方に付け替える
         $Order = $this->createOrder($this->Order->getCustomer());
@@ -242,7 +248,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
             self::assertEquals($OrderStatus, $this->Order->getOrderStatus());
         } catch (InvalidArgumentException $e) {
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         }
 
         // ２個目の出荷情報を出荷済みに変更
@@ -258,7 +264,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
             self::assertEquals($OrderStatus, $this->Order->getOrderStatus());
         } catch (InvalidArgumentException $e) {
             // 通らない
-            self::assertTrue(false);
+            self::fail();
         }
     }
 }

--- a/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
+++ b/Tests/GraphQL/Mutation/UpdateShippedMutationTest.php
@@ -105,7 +105,7 @@ class UpdateShippedMutationTest extends EccubeTestCase
     /**
      * 引数のバリデーションチェック
      *
-     * @param \DateTime[]|lowercase-string[]|int[]|bool[] $args
+     * @param array<string, bool|int|string|\DateTime> $args
      */
     #[DataProvider('validateArgsProvider')]
     public function testValidateArgs(array $args = [], ?string $message = null): void

--- a/Tests/GraphQL/SchemaTest.php
+++ b/Tests/GraphQL/SchemaTest.php
@@ -20,11 +20,12 @@ use GraphQL\Executor\ExecutionResult;
 use GraphQL\Server\Helper;
 use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Plugin\Api44\GraphQL\Schema;
 
 class SchemaTest extends EccubeTestCase
 {
-    public function testQueryProduct()
+    public function testQueryProduct(): void
     {
         $query = '{ product(id:2) { id } }';
 
@@ -37,7 +38,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryProducts()
+    public function testQueryProducts(): void
     {
         $query = '{
           products (page: 1, limit: 2, create_datetime_start: "2018-09-28T10:14:52+00:00") {
@@ -59,7 +60,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryProductsWithVariables()
+    public function testQueryProductsWithVariables(): void
     {
         $query = '
         query productsQuery(
@@ -94,7 +95,7 @@ class SchemaTest extends EccubeTestCase
         ], $result);
     }
 
-    public function testQueryConnectionWithEdges()
+    public function testQueryConnectionWithEdges(): void
     {
         $query = '{
             products {
@@ -126,7 +127,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryConnectionWithNodes()
+    public function testQueryConnectionWithNodes(): void
     {
         $query = '{
             products {
@@ -152,7 +153,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryPageInfo()
+    public function testQueryPageInfo(): void
     {
         $query = '{
             products {
@@ -188,7 +189,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryPageInfoFirstPage()
+    public function testQueryPageInfoFirstPage(): void
     {
         $query = '{
             products(page: 1, limit: 1) {
@@ -221,7 +222,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    public function testQueryPageInfoLastPage()
+    public function testQueryPageInfoLastPage(): void
     {
         $query = '{
             products(page: 2, limit: 1) {
@@ -254,8 +255,8 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('queryWithPaginationProvider')]
-    public function testQueryWithPagination($page, $limit, $expectedErrorMessage = null)
+    #[DataProvider('queryWithPaginationProvider')]
+    public function testQueryWithPagination(string $page, string $limit, ?string $expectedErrorMessage = null): void
     {
         $query = '{ products(page: '.$page.', limit: '.$limit.') { nodes { id } } }';
 
@@ -268,7 +269,10 @@ class SchemaTest extends EccubeTestCase
         }
     }
 
-    public static function queryWithPaginationProvider()
+    /**
+     * @return string[][]
+     */
+    public static function queryWithPaginationProvider(): array
     {
         return [
             ['1', '1'],
@@ -277,8 +281,8 @@ class SchemaTest extends EccubeTestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('queryWithDateTimeProvider')]
-    public function testQueryWithDateTime($dateTime, $expectedErrorMessage = null)
+    #[DataProvider('queryWithDateTimeProvider')]
+    public function testQueryWithDateTime(string $dateTime, ?string $expectedErrorMessage = null): void
     {
         $query = '{ products(create_datetime_start: "'.$dateTime.'") { nodes { id } } }';
 
@@ -291,7 +295,10 @@ class SchemaTest extends EccubeTestCase
         }
     }
 
-    public static function queryWithDateTimeProvider()
+    /**
+     * @return string[][]
+     */
+    public static function queryWithDateTimeProvider(): array
     {
         return [
             ['2020-07-30T12:57:08+09:00'],
@@ -301,7 +308,7 @@ class SchemaTest extends EccubeTestCase
         ];
     }
 
-    public function testMutationUpdateStock()
+    public function testMutationUpdateStock(): void
     {
         $query = 'mutation UpdateProductStock(
             $code: String!,
@@ -332,7 +339,7 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query, $variables));
     }
 
-    public function testMutationUpdateShipped()
+    public function testMutationUpdateShipped(): void
     {
         // 出荷可能な受注を作成
         $Customer = $this->createCustomer();
@@ -373,7 +380,7 @@ class SchemaTest extends EccubeTestCase
         ], $result);
     }
 
-    public function testMutationUpdateShippedWithVariables()
+    public function testMutationUpdateShippedWithVariables(): void
     {
         // 出荷可能な受注を作成
         $Customer = $this->createCustomer();
@@ -420,7 +427,12 @@ class SchemaTest extends EccubeTestCase
         ], $this->executeQuery($query, $variables));
     }
 
-    private function executeQuery($query, $variables = null, $readonly = false)
+    /**
+     * @param array<string, mixed>|string|null $variables
+     *
+     * @return array<string, mixed>
+     */
+    private function executeQuery(string $query, array|string|null $variables = null, bool $readonly = false): array
     {
         $op = OperationParams::create(['query' => $query, 'variables' => $variables], $readonly);
         $helper = new Helper();

--- a/Tests/GraphQL/TypesTest.php
+++ b/Tests/GraphQL/TypesTest.php
@@ -18,6 +18,7 @@ use Eccube\Entity\Customer;
 use Eccube\Entity\Member;
 use Eccube\Entity\Product;
 use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Plugin\Api44\GraphQL\Types;
 
 class TypesTest extends EccubeTestCase
@@ -31,15 +32,18 @@ class TypesTest extends EccubeTestCase
         $this->types = self::getContainer()->get(Types::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('hideSensitiveFieldsProvider')]
-    public function testHideSensitiveFields($entityClass, $field, $expectExists)
+    #[DataProvider('hideSensitiveFieldsProvider')]
+    public function testHideSensitiveFields(string $entityClass, string $field, bool $expectExists): void
     {
         $type = $this->types->get($entityClass);
 
         self::assertEquals($expectExists, $type->hasField($field));
     }
 
-    public static function hideSensitiveFieldsProvider()
+    /**
+     * @return string[][]|bool[][]
+     */
+    public static function hideSensitiveFieldsProvider(): array
     {
         return [
             [Product::class, 'name', true],

--- a/Tests/GraphQL/TypesTest.php
+++ b/Tests/GraphQL/TypesTest.php
@@ -41,7 +41,7 @@ class TypesTest extends EccubeTestCase
     }
 
     /**
-     * @return string[][]|bool[][]
+     * @return list<array{class-string, string, bool}>
      */
     public static function hideSensitiveFieldsProvider(): array
     {

--- a/Tests/Service/WebHookServiceTest.php
+++ b/Tests/Service/WebHookServiceTest.php
@@ -21,7 +21,7 @@ use Plugin\Api44\Service\WebHookService;
 class WebHookServiceTest extends EccubeTestCase
 {
     /** @var WebHookService */
-    private ?WebHookService $service;
+    private ?WebHookService $service = null;
 
     public function setUp(): void
     {
@@ -30,7 +30,7 @@ class WebHookServiceTest extends EccubeTestCase
         $this->service = self::getContainer()->get(WebHookService::class);
     }
 
-    public function testCreateRequestWithSecret()
+    public function testCreateRequestWithSecret(): void
     {
         $WebHook = new WebHook();
         $WebHook->setPayloadUrl('http://localhost/hook');
@@ -47,7 +47,7 @@ class WebHookServiceTest extends EccubeTestCase
         );
     }
 
-    public function testCreateRequestWithoutSecret()
+    public function testCreateRequestWithoutSecret(): void
     {
         $WebHook = new WebHook();
         $WebHook->setPayloadUrl('http://localhost/hook');
@@ -68,7 +68,7 @@ class WebHookServiceTest extends EccubeTestCase
      *
      * @throws \ReflectionException
      */
-    private function invokeCreateRequest($payload, WebHook $WebHook): Request
+    private function invokeCreateRequest(string $payload, WebHook $WebHook): Request
     {
         $rc = new \ReflectionClass($this->service);
         $method = $rc->getMethod('createRequest');

--- a/Tests/Web/Admin/LoginControllerTest.php
+++ b/Tests/Web/Admin/LoginControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class LoginControllerTest extends AbstractWebTestCase
 {
-    public function testRoutingAdminLogin()
+    public function testRoutingAdminLogin(): void
     {
         $this->client->request('GET', $this->generateUrl('admin_login'));
 
@@ -29,7 +29,7 @@ class LoginControllerTest extends AbstractWebTestCase
         );
     }
 
-    public function testRoutingAdminLoginCheck()
+    public function testRoutingAdminLoginCheck(): void
     {
         // see https://stackoverflow.com/a/38661340/4956633
         $this->client->request(
@@ -44,7 +44,7 @@ class LoginControllerTest extends AbstractWebTestCase
         $this->assertNotNull(self::getContainer()->get('security.token_storage')->getToken(), 'ログインしているかどうか');
     }
 
-    public function testRoutingAdminLoginログインしていない場合はログイン画面を表示()
+    public function testRoutingAdminLoginログインしていない場合はログイン画面を表示(): void
     {
         $this->client->request('GET', $this->generateUrl('admin_homepage'));
 
@@ -53,7 +53,7 @@ class LoginControllerTest extends AbstractWebTestCase
             $this->generateUrl('admin_login', [], UrlGeneratorInterface::ABSOLUTE_URL)));
     }
 
-    public function testRoutingAdminOauth2Authorizeログインしていない場合はログイン画面を表示()
+    public function testRoutingAdminOauth2Authorizeログインしていない場合はログイン画面を表示(): void
     {
         $this->client->request('GET', $this->generateUrl('oauth2_authorize'));
 
@@ -62,7 +62,7 @@ class LoginControllerTest extends AbstractWebTestCase
             $this->generateUrl('admin_login', [], UrlGeneratorInterface::ABSOLUTE_URL)));
     }
 
-    public function testRoutingOauth2Authorizeログインしていない場合はログイン画面を表示()
+    public function testRoutingOauth2Authorizeログインしていない場合はログイン画面を表示(): void
     {
         $this->client->request('GET', $this->generateUrl('oauth2_authorize'));
 

--- a/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
@@ -16,6 +16,7 @@ namespace Plugin\Api44\Tests\Web\Admin\OAuth2Bundle;
 use Eccube\Common\Constant;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthorizationControllerTest extends AbstractAdminWebTestCase
@@ -25,7 +26,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         parent::setUp();
     }
 
-    public function testRoutingAdminOauth2Authorizeログインしている場合は権限移譲確認画面を表示()
+    public function testRoutingAdminOauth2Authorizeログインしている場合は権限移譲確認画面を表示(): void
     {
         /** @var Client $Client */
         $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
@@ -50,7 +51,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         );
     }
 
-    public function testRoutingAdminOauth2Authorize権限移譲を許可()
+    public function testRoutingAdminOauth2Authorize権限移譲を許可(): void
     {
         /** @var Client $Client */
         $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
@@ -95,7 +96,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         self::assertTrue(isset($callbackParams['code']));
     }
 
-    public function testRoutingAdminOauth2Authorize権限移譲を許可しない()
+    public function testRoutingAdminOauth2Authorize権限移譲を許可しない(): void
     {
         /** @var Client $Client */
         $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
@@ -141,7 +142,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         self::assertEquals('access_denied', $callbackParams['error']);
     }
 
-    public function testRoutingAdminOauth2Authorize権限移譲を許可パラメータが足りない場合()
+    public function testRoutingAdminOauth2Authorize権限移譲を許可パラメータが足りない場合(): void
     {
         $parameters = [
             'oauth_authorization' => [
@@ -163,8 +164,8 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         $this->assertFalse($this->client->getResponse()->isRedirection());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('xssSnippetsProvider')]
-    public function testRoutingAdminOauth2AuthorizeXSS($snippet)
+    #[DataProvider('xssSnippetsProvider')]
+    public function testRoutingAdminOauth2AuthorizeXSS(string $snippet): void
     {
         // 基本設定＞店舗設定へ移動
         $shop_url = $this->generateUrl('admin_setting_shop');
@@ -245,7 +246,10 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         $this->assertEquals($snippet.' / TOPページ', $title);
     }
 
-    public static function xssSnippetsProvider()
+    /**
+     * @return string[][]
+     */
+    public static function xssSnippetsProvider(): array
     {
         return [
             ['<script>alert(1)</script>'],
@@ -254,7 +258,10 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         ];
     }
 
-    private function parseCallbackParams(Response $response)
+    /**
+     * @return mixed[][]|string[]
+     */
+    private function parseCallbackParams(Response $response): array
     {
         $url = parse_url($response->headers->get('Location'));
         $redirectParams = [];

--- a/Tests/Web/Admin/OAuthControllerTest.php
+++ b/Tests/Web/Admin/OAuthControllerTest.php
@@ -35,19 +35,19 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->clientManager = self::getContainer()->get(ClientManager::class);
     }
 
-    public function testRoutingAdminSettingSystemOAuth2Client()
+    public function testRoutingAdminSettingSystemOAuth2Client(): void
     {
         $this->client->request('GET', $this->generateUrl('admin_api_oauth'));
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
-    public function testRoutingAdminSettingSystemOAuth2ClientCreate()
+    public function testRoutingAdminSettingSystemOAuth2ClientCreate(): void
     {
         $this->client->request('GET', $this->generateUrl('admin_api_oauth_new'));
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
-    public function testRoutingAdminSettingSystemOAuth2ClientDelete()
+    public function testRoutingAdminSettingSystemOAuth2ClientDelete(): void
     {
         // before
         $identifier = hash('md5', random_bytes(16));
@@ -67,7 +67,7 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->assertMatchesRegularExpression('/削除しました/u', $crawler->filter('div.alert-success')->text());
     }
 
-    public function testOAuth2ClientCreateSubmit()
+    public function testOAuth2ClientCreateSubmit(): void
     {
         // before
         $formData = $this->createFormData();
@@ -102,7 +102,7 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->assertMatchesRegularExpression('/保存しました/u', $crawler->filter('div.alert-success')->text());
     }
 
-    public function testOAuth2ClientCreateSubmitFail()
+    public function testOAuth2ClientCreateSubmitFail(): void
     {
         // before
         $formData = $this->createFormData();
@@ -121,7 +121,7 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->assertMatchesRegularExpression('/入力されていません。/u', $crawler->filter('span.form-error-message')->text());
     }
 
-    public function testOAuth2ClientDeleteIdentifierNotFound()
+    public function testOAuth2ClientDeleteIdentifierNotFound(): void
     {
         // before
         $identifier = hash('md5', random_bytes(16));
@@ -138,7 +138,10 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->assertMatchesRegularExpression('/既に削除されています/u', $crawler->filter('div.alert-danger')->text());
     }
 
-    protected function createFormData()
+    /**
+     * @return array<string, lowercase-string|string[]>
+     */
+    protected function createFormData(): array
     {
         return [
             '_token' => 'dummy',

--- a/Tests/Web/ApiControllerTest.php
+++ b/Tests/Web/ApiControllerTest.php
@@ -19,11 +19,10 @@ use League\Bundle\OAuth2ServerBundle\Entity\AccessToken;
 use League\Bundle\OAuth2ServerBundle\Entity\Scope;
 use League\Bundle\OAuth2ServerBundle\Manager\Doctrine\ClientManager;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
-use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
-use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ApiControllerTest extends AbstractWebTestCase
 {
@@ -31,16 +30,10 @@ class ApiControllerTest extends AbstractWebTestCase
     private ?ClientManager $clientManager = null;
 
     /** @var ClientRepositoryInterface */
-    private ?ClientRepositoryInterface $clientRepository;
+    private ?ClientRepositoryInterface $clientRepository = null;
 
     /** @var AccessTokenRepositoryInterface */
-    private ?AccessTokenRepositoryInterface $accessTokenRepository;
-
-    /** @var ScopeRepositoryInterface */
-    private ?ScopeRepositoryInterface $scopeRepositoryInterface;
-
-    /** @var AuthorizationServer */
-    private ?AuthorizationServer $authorizationServer;
+    private ?AccessTokenRepositoryInterface $accessTokenRepository = null;
 
     public function setUp(): void
     {
@@ -48,12 +41,13 @@ class ApiControllerTest extends AbstractWebTestCase
         $this->clientManager = self::getContainer()->get(ClientManager::class);
         $this->clientRepository = self::getContainer()->get(ClientRepositoryInterface::class);
         $this->accessTokenRepository = self::getContainer()->get(AccessTokenRepositoryInterface::class);
-        $this->authorizationServer = self::getContainer()->get(AuthorizationServer::class);
-        $this->scopeRepositoryInterface = self::getContainer()->get(ScopeRepositoryInterface::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('permissionProvider')]
-    public function testPermission($scopes, $query, $expectedErrorMessage = null)
+    /**
+     * @param string[] $scopes
+     */
+    #[DataProvider('permissionProvider')]
+    public function testPermission(array $scopes, string $query, ?string $expectedErrorMessage = null): void
     {
         $token = $this->newAccessToken($scopes);
         $this->client->request('POST', $this->generateUrl('api'), [], [], [
@@ -71,7 +65,10 @@ class ApiControllerTest extends AbstractWebTestCase
         }
     }
 
-    public static function permissionProvider()
+    /**
+     * @return string[][]|string[][][]
+     */
+    public static function permissionProvider(): array
     {
         $query = '{ product(id:1) { id, name } }';
         $mutation = 'mutation { updateProductStock(code: "sand-01", stock: 10, stock_unlimited:false) { id } }';
@@ -86,17 +83,20 @@ class ApiControllerTest extends AbstractWebTestCase
         ];
     }
 
-    private function newAccessToken($scopes)
+    /**
+     * @param string[] $scopes
+     */
+    private function newAccessToken(array $scopes): string
     {
         $identifier = hash('md5', random_bytes(16));
         $secret = hash('sha512', random_bytes(32));
 
         $client = new Client('', $identifier, $secret);
-        $client->setScopes(...array_map(function ($s) {
+        $client->setScopes(...array_map(function (string $s): \League\Bundle\OAuth2ServerBundle\ValueObject\Scope {
             return new \League\Bundle\OAuth2ServerBundle\ValueObject\Scope($s);
         }, $scopes));
         $this->clientManager->save($client);
-        $clientEntity = $this->clientRepository->getClientEntity($identifier, 'authorization_code', $secret);
+        $clientEntity = $this->clientRepository->getClientEntity($identifier);
 
         $accessTokenEntity = new AccessToken();
         $accessTokenEntity->setIdentifier($identifier);
@@ -106,7 +106,7 @@ class ApiControllerTest extends AbstractWebTestCase
         $accessTokenEntity->setPrivateKey(new CryptKey(self::getContainer()->get(EccubeConfig::class)->get('kernel.project_dir').'/app/PluginData/Api44/oauth/private.key'));
         $accessTokenEntity->initJwtConfiguration();
 
-        array_walk($scopes, function ($s) use ($accessTokenEntity) {
+        array_walk($scopes, function (string $s) use ($accessTokenEntity): void {
             $scope = new Scope();
             $scope->setIdentifier($s);
             $accessTokenEntity->addScope($scope);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 6
+    paths:
+        - .
+    excludePaths:
+        - Resource/*
+        - Tests/bootstrap.php
+    doctrine:
+        objectManagerLoader: ../../../tests/object-manager.php
+        ormRepositoryClass: Eccube\Repository\AbstractRepository


### PR DESCRIPTION
## 概要
4.4プラグイン を PHPStan level 6 に対応。

## 詳細
- テストがブランチ名`xxx/xxxxxxxx`のスラッシュ入りで動かなかったため、本体と合わせる
- PHPStanを追加


- メソッド/プロパティ/配列に型宣言を付与
- 型不整合を修正（`WebHook` の `AbstractEntity` 継承、`EntityManagerInterface` 化、`Node` 引数 + ガード 等）
- `RuntimeException` にパスを例外コードとして渡していたバグを修正
- CI に PHPStan ステップを追加
- ローカルで php-cs-fixerを実行と修正