### PR TITLE
feat: MCP サーバ用 OAuth2 scope と firewall を追加

### DIFF
--- a/Command/CleanupDcrClientsCommand.php
+++ b/Command/CleanupDcrClientsCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Command;
+
+use Plugin\Api44\Service\DcrClientCleaner;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * DCR (動的クライアント登録) で量産される死蔵クライアントを掃除する。
+ *
+ * 登録から --days を過ぎ、 有効な access/refresh トークンを持たない DCR クライアントを削除する。
+ * 定期実行 (cron) を想定。 --dry-run で対象だけ確認できる。
+ * 掃除対象は追跡レコードのある client のみ (導入前/記録漏れの client は対象外)。
+ */
+#[AsCommand(
+    name: 'eccube:api:mcp:cleanup-dcr-clients',
+    description: 'Remove abandoned DCR-registered OAuth clients that have no valid tokens.'
+)]
+class CleanupDcrClientsCommand extends Command
+{
+    private const DEFAULT_GRACE_DAYS = 30;
+
+    public function __construct(
+        private readonly DcrClientCleaner $cleaner,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days', null, InputOption::VALUE_REQUIRED, 'Grace period in days; clients registered within this window are never removed', (string) self::DEFAULT_GRACE_DAYS)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'List clients that would be removed without deleting them');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $days = filter_var($input->getOption('days'), FILTER_VALIDATE_INT);
+        if (false === $days || $days < 0) {
+            $io->error('--days must be a non-negative integer.');
+
+            return Command::INVALID;
+        }
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        try {
+            $result = $this->cleaner->cleanup(new \DateTime(), $days, $dryRun);
+        } catch (\Throwable $e) {
+            // 破壊的操作の失敗を握り潰さず記録する (トランザクションは rollback 済み = 未変更)
+            $this->logger->error('DCR cleanup failed', ['exception' => $e, 'days' => $days, 'dry_run' => $dryRun]);
+            $io->error('DCR cleanup failed; no clients were removed. See logs for details.');
+
+            return Command::FAILURE;
+        }
+
+        // 破壊的・自動実行の監査証跡として、 いつ何件消したかを残す
+        $this->logger->info('DCR cleanup completed', [
+            'dry_run' => $dryRun,
+            'examined' => $result->examinedCount,
+            'kept_active' => $result->keptActiveCount,
+            'deleted' => $result->deletedCount(),
+            'deleted_client_ids' => $result->deletedClientIdentifiers,
+        ]);
+
+        $io->title($dryRun ? 'DCR cleanup (dry-run)' : 'DCR cleanup');
+        $io->listing($result->deletedClientIdentifiers);
+        $io->table(['examined', 'kept (active)', $dryRun ? 'to delete' : 'deleted'], [
+            [$result->examinedCount, $result->keptActiveCount, $result->deletedCount()],
+        ]);
+        $io->success(sprintf(
+            '%s %d abandoned DCR client(s); kept %d active.',
+            $dryRun ? 'Would remove' : 'Removed',
+            $result->deletedCount(),
+            $result->keptActiveCount,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Controller/Admin/McpTokenController.php
+++ b/Controller/Admin/McpTokenController.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Controller\Admin;
+
+use Eccube\Controller\AbstractController;
+use Eccube\Entity\Member;
+use Plugin\Api44\Form\Type\Admin\McpTokenType;
+use Plugin\Api44\Repository\McpTokenRepository;
+use Plugin\Api44\Service\McpTokenService;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+class McpTokenController extends AbstractController
+{
+    public function __construct(
+        private readonly McpTokenService $mcpTokenService,
+        private readonly McpTokenRepository $mcpTokenRepository,
+    ) {
+    }
+
+    /**
+     * MCP トークン発行画面。 送信時にトークンを発行し、 JWT を 1 度だけ表示する。
+     */
+    #[Route(path: '/%eccube_admin_route%/api/oauth/mcp/new', name: 'admin_api_mcp_token_new', methods: ['GET', 'POST'])]
+    public function create(Request $request): Response
+    {
+        $form = $this->createForm(McpTokenType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $member = $this->getUser();
+            if (!$member instanceof Member) {
+                throw new AccessDeniedHttpException();
+            }
+
+            try {
+                // sub はフォーム入力でなく操作中の Member 固定 (なりすまし防止)
+                $token = $this->mcpTokenService->issue(
+                    $member,
+                    (string) $form->get('label')->getData(),
+                    $form->get('scopes')->getData(),
+                    (int) $form->get('expire')->getData(),
+                );
+
+                // 発行直後のみ JWT を表示する (再表示不可)。 redirect すると失われるため render する
+                return $this->render('@Api44/admin/OAuth/mcp_token_issued.twig', [
+                    'token' => $token,
+                    'label' => (string) $form->get('label')->getData(),
+                ]);
+            } catch (\Exception $e) {
+                $this->addError(trans('admin.common.save_error'), 'admin');
+                // 例外クラスと発行者を残し、 万一の発行失敗を追跡可能にする
+                log_error('MCP トークン発行エラー', ['exception' => $e, 'member_id' => $member->getId()]);
+            }
+        }
+
+        return $this->render('@Api44/admin/OAuth/mcp_token.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * MCP トークンを失効する (league token を revoke → 即 401)。
+     */
+    #[Route(path: '/%eccube_admin_route%/api/oauth/mcp/revoke/{id}', requirements: ['id' => '\d+'], name: 'admin_api_mcp_token_revoke', methods: ['DELETE'])]
+    public function revoke(Request $request, int $id): RedirectResponse
+    {
+        $this->isTokenValid();
+
+        $mcpToken = $this->mcpTokenRepository->find($id);
+        if (null === $mcpToken) {
+            $this->addError('admin.common.delete_error_already_deleted', 'admin');
+
+            return $this->redirectToRoute('admin_api_oauth');
+        }
+
+        try {
+            $found = $this->mcpTokenService->revoke($mcpToken);
+            if ($found) {
+                $this->addSuccess('admin.common.delete_complete', 'admin');
+            } else {
+                // 失効対象の league token が見つからなかった (期限切れ削除済み等)。 メタは削除したが操作者に明示する
+                $this->addWarning('api.admin.oauth.mcp_token.revoke__not_found', 'admin');
+            }
+        } catch (\Exception $e) {
+            $this->addError('admin.common.delete_error', 'admin');
+            log_error('MCP トークン失効エラー', ['exception' => $e, 'id' => $id]);
+        }
+
+        return $this->redirectToRoute('admin_api_oauth');
+    }
+}

--- a/Controller/Admin/McpTokenController.php
+++ b/Controller/Admin/McpTokenController.php
@@ -14,6 +14,7 @@
 namespace Plugin\Api44\Controller\Admin;
 
 use Eccube\Controller\AbstractController;
+use Eccube\Entity\Master\Authority;
 use Eccube\Entity\Member;
 use Plugin\Api44\Form\Type\Admin\McpTokenType;
 use Plugin\Api44\Repository\McpTokenRepository;
@@ -43,7 +44,10 @@ class McpTokenController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $member = $this->getUser();
-            if (!$member instanceof Member) {
+            // 制限管理者 (authority != ADMIN) は URL 認可で受注/顧客画面等を塞がれるが、 stateless な mcp firewall では
+            // その制限が再評価されない。 全 scope トークンを発行させると管理画面の権限制限を第二の扉で回避できるため、
+            // 発行時に ADMIN を要求する (対話型同意フロー AuthorizationRequestResolveListener と対称)。
+            if (!$member instanceof Member || Authority::ADMIN !== $member->getAuthority()?->getId()) {
                 throw new AccessDeniedHttpException();
             }
 

--- a/Controller/Admin/McpTokenController.php
+++ b/Controller/Admin/McpTokenController.php
@@ -57,10 +57,14 @@ class McpTokenController extends AbstractController
                 );
 
                 // 発行直後のみ JWT を表示する (再表示不可)。 redirect すると失われるため render する
-                return $this->render('@Api44/admin/OAuth/mcp_token_issued.twig', [
+                $response = $this->render('@Api44/admin/OAuth/mcp_token_issued.twig', [
                     'token' => $token,
                     'label' => (string) $form->get('label')->getData(),
                 ]);
+                // bearer token を HTML に埋め込む画面なので、 ブラウザや共有端末のキャッシュに残さない
+                $response->headers->set('Cache-Control', 'no-store, private');
+
+                return $response;
             } catch (\Exception $e) {
                 $this->addError(trans('admin.common.save_error'), 'admin');
                 // 例外クラスと発行者を残し、 万一の発行失敗を追跡可能にする

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -129,7 +129,7 @@ class OAuthController extends AbstractController
      *
      * @return RedirectResponse
      */
-    #[Route(path: '/%eccube_admin_route%/api/oauth/delete/{identifier}', requirements: ['identifier' => '\w+'], name: 'admin_api_oauth_delete', methods: ['DELETE'])]
+    #[Route(path: '/%eccube_admin_route%/api/oauth/delete/{identifier}', requirements: ['identifier' => '[\w\-]+'], name: 'admin_api_oauth_delete', methods: ['DELETE'])]
     public function delete(Request $request, string $identifier): RedirectResponse
     {
         $this->isTokenValid();

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -26,6 +26,8 @@ use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
 use Plugin\Api44\Form\Type\Admin\ClientType;
+use Plugin\Api44\Repository\McpTokenRepository;
+use Plugin\Api44\Service\McpTokenService;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -58,6 +60,7 @@ class OAuthController extends AbstractController
         ClientManagerInterface $clientManager,
         AccessTokenManagerInterface $accessTokenManager,
         RefreshTokenManagerInterface $refreshTokenManager,
+        private readonly McpTokenRepository $mcpTokenRepository,
     ) {
         $this->clientManager = $clientManager;
         $this->accessTokenManager = $accessTokenManager;
@@ -74,10 +77,15 @@ class OAuthController extends AbstractController
     public function index(Request $request): Response
     {
         $criteria = ClientFilter::create();
-        $clients = $this->clientManager->list($criteria);
+        // MCP トークン用の内部クライアント (mcp_pat) は API クライアント一覧に出さない
+        $clients = array_values(array_filter(
+            $this->clientManager->list($criteria),
+            static fn (ClientInterface $client): bool => $client->getIdentifier() !== McpTokenService::CLIENT_IDENTIFIER,
+        ));
 
         return $this->render('@Api44/admin/OAuth/index.twig', [
             'clients' => $clients,
+            'mcpTokens' => $this->mcpTokenRepository->findAllOrderByCreateDate(),
         ]);
     }
 

--- a/Controller/ClientRegistrationController.php
+++ b/Controller/ClientRegistrationController.php
@@ -19,6 +19,7 @@ use League\Bundle\OAuth2ServerBundle\Model\Client;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Entity\DcrClient;
 use Plugin\Api44\Service\McpTokenService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -124,6 +125,19 @@ class ClientRegistrationController extends AbstractController
             $this->logger->error('MCP DCR client persistence failed', ['ip' => $ip, 'exception' => $e]);
 
             return $this->error('server_error', 'Failed to register client', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        // 死蔵クライアント掃除の grace 判定用に登録時刻を記録する (best-effort)。
+        // 記録に失敗しても client 発行は成立させる (記録漏れの client は自動掃除の対象から外れるだけ)。
+        try {
+            $dcrRecord = new DcrClient();
+            $dcrRecord->setClientIdentifier($identifier);
+            $dcrRecord->setCreateDate(new \DateTime());
+            $this->entityManager->persist($dcrRecord);
+            $this->entityManager->flush();
+        } catch (\Throwable $e) {
+            // 記録漏れの client は作成時刻を持たず、 自動掃除 (CleanupDcrClientsCommand) の対象から外れる (リークになる)
+            $this->logger->warning('MCP DCR registration record persistence failed; this client will be excluded from automatic cleanup (leak risk)', ['client_id' => $identifier, 'exception' => $e]);
         }
 
         $this->logger->info('MCP DCR client registered', [

--- a/Controller/ClientRegistrationController.php
+++ b/Controller/ClientRegistrationController.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Controller;
+
+use Eccube\Controller\AbstractController;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Service\McpTokenService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RFC 7591 動的クライアント登録 (DCR)。 MCP クライアント (Claude Desktop / mcp-remote) が
+ * 自分の redirect_uri を登録して client_id を得るための公開エンドポイント。
+ *
+ * セキュリティ:
+ *   - 公開だが client_id を作るだけ。 データ到達には別途 /authorize での管理ログイン+同意が必須。
+ *   - redirect_uri は https または loopback (localhost/127.0.0.1/[::1]) のみ許可。 さらにパーサ差異
+ *     (PHP parse_url とブラウザの WHATWG URL) による host 詐称を防ぐため userinfo(@)/バックスラッシュ/
+ *     fragment を含む URI は拒否 (fail-closed)。
+ *   - 付与する grant/scope は MCP read に固定 (クライアント要求の write/他 grant は無視)。
+ *   - IP 単位 + グローバルの 2 段レート制限で濫用 (死蔵クライアント量産・IP 偽装回避) を抑止。
+ *   - DCR 由来は client 名に prefix を付け、 運用者が識別・棚卸しできるようにする。
+ *
+ * 前提: 本番では TRUSTED_HOSTS / TRUSTED_PROXIES を設定すること
+ * (Host ヘッダ詐称によるメタデータ汚染・IP 偽装でのレート制限回避を防ぐため)。
+ */
+class ClientRegistrationController extends AbstractController
+{
+    /**
+     * DCR で作成した client を識別するための名前 prefix (棚卸し用)。
+     */
+    public const CLIENT_NAME_PREFIX = 'DCR:';
+
+    public function __construct(
+        private readonly ClientManagerInterface $clientManager,
+        private readonly RateLimiterFactory $mcpDcrRegisterLimiter,
+        private readonly RateLimiterFactory $mcpDcrRegisterGlobalLimiter,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route(path: '/register', name: 'mcp_oauth_register', methods: ['POST'])]
+    public function register(Request $request): JsonResponse
+    {
+        $ip = $request->getClientIp() ?? 'unknown';
+
+        // グローバル上限: IP 偽装 (X-Forwarded-For 回転等) でも無制限に client を作らせない最終バックストップ
+        if (!$this->mcpDcrRegisterGlobalLimiter->create('dcr:global')->consume()->isAccepted()) {
+            $this->logger->warning('MCP DCR rejected: global rate limit', ['ip' => $ip]);
+
+            return $this->error('rate_limited', 'Too many registration requests', Response::HTTP_TOO_MANY_REQUESTS);
+        }
+        if (!$this->mcpDcrRegisterLimiter->create('dcr:'.$ip)->consume()->isAccepted()) {
+            $this->logger->warning('MCP DCR rejected: per-IP rate limit', ['ip' => $ip]);
+
+            return $this->error('rate_limited', 'Too many registration requests', Response::HTTP_TOO_MANY_REQUESTS);
+        }
+
+        $payload = json_decode((string) $request->getContent(), true);
+        if (!is_array($payload)) {
+            return $this->error('invalid_client_metadata', 'Request body must be a JSON object');
+        }
+
+        $requestedRedirectUris = $payload['redirect_uris'] ?? null;
+        if (!is_array($requestedRedirectUris) || [] === $requestedRedirectUris) {
+            return $this->error('invalid_redirect_uri', 'redirect_uris is required');
+        }
+
+        $redirectUris = [];
+        foreach ($requestedRedirectUris as $uri) {
+            if (!is_string($uri) || !$this->isAllowedRedirectUri($uri)) {
+                $this->logger->notice('MCP DCR rejected: disallowed redirect_uri', [
+                    'ip' => $ip,
+                    'redirect_uri' => is_string($uri) ? $uri : '(non-string)',
+                ]);
+
+                return $this->error('invalid_redirect_uri', 'redirect_uri not allowed');
+            }
+            $redirectUris[] = new RedirectUri($uri);
+        }
+
+        // client_name は公開 INSERT。 長さ制限＋制御文字除去で保存先汚染・肥大化を防ぐ
+        $rawName = is_string($payload['client_name'] ?? null) ? $payload['client_name'] : 'MCP client';
+        $clientName = mb_substr((string) preg_replace('/[[:cntrl:]]+/u', '', $rawName), 0, 200);
+        if ('' === $clientName) {
+            $clientName = 'MCP client';
+        }
+
+        $identifier = bin2hex(random_bytes(16));
+
+        // public client (secret なし)。 grant/scope はクライアント要求を無視して MCP read に固定
+        $client = new Client(self::CLIENT_NAME_PREFIX.$clientName, $identifier, null);
+        $client->setActive(true);
+        $client->setRedirectUris(...$redirectUris);
+        $client->setGrants(new Grant('authorization_code'), new Grant('refresh_token'));
+        $client->setScopes(...array_map(
+            static fn (string $scope): Scope => new Scope($scope),
+            McpTokenService::AVAILABLE_SCOPES,
+        ));
+
+        try {
+            $this->clientManager->save($client);
+        } catch (\Throwable $e) {
+            // セキュリティ関連の公開 INSERT 失敗を握り潰さず記録し、 raw 500 を漏らさない
+            $this->logger->error('MCP DCR client persistence failed', ['ip' => $ip, 'exception' => $e]);
+
+            return $this->error('server_error', 'Failed to register client', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $this->logger->info('MCP DCR client registered', [
+            'client_id' => $identifier,
+            'redirect_uris' => array_map(static fn (RedirectUri $u): string => (string) $u, $redirectUris),
+            'ip' => $ip,
+        ]);
+
+        // RFC 7591 の登録レスポンス (201)
+        return new JsonResponse([
+            'client_id' => $identifier,
+            'client_id_issued_at' => time(),
+            'token_endpoint_auth_method' => 'none',
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'response_types' => ['code'],
+            'redirect_uris' => array_map(static fn (RedirectUri $u): string => (string) $u, $redirectUris),
+            'scope' => implode(' ', McpTokenService::AVAILABLE_SCOPES),
+        ], Response::HTTP_CREATED);
+    }
+
+    /**
+     * redirect_uri は https、 または loopback の http (localhost/127.0.0.1/[::1]) のみ許可する。
+     *
+     * パーサ差異対策: `\`/`@`/`#` を含む URI は、 PHP parse_url とブラウザ (WHATWG URL) で
+     * host 解釈がズレ得る (例: `http://evil.com\@localhost/cb` は PHP では host=localhost だが
+     * ブラウザでは evil.com)。 これらは fail-closed で拒否する。
+     */
+    private function isAllowedRedirectUri(string $uri): bool
+    {
+        if (str_contains($uri, '\\') || str_contains($uri, '@') || str_contains($uri, '#')) {
+            return false;
+        }
+
+        $parts = parse_url($uri);
+        if (false === $parts || !isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+        if (isset($parts['user']) || isset($parts['pass']) || isset($parts['fragment'])) {
+            return false;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host']);
+
+        if ('https' === $scheme) {
+            return true;
+        }
+
+        if ('http' === $scheme) {
+            return in_array($host, ['localhost', '127.0.0.1', '::1', '[::1]'], true);
+        }
+
+        return false;
+    }
+
+    private function error(string $error, string $description, int $status = Response::HTTP_BAD_REQUEST): JsonResponse
+    {
+        return new JsonResponse(['error' => $error, 'error_description' => $description], $status);
+    }
+}

--- a/Controller/ClientRegistrationController.php
+++ b/Controller/ClientRegistrationController.php
@@ -64,14 +64,17 @@ class ClientRegistrationController extends AbstractController
     {
         $ip = $request->getClientIp() ?? 'unknown';
 
-        // グローバル上限: IP 偽装 (X-Forwarded-For 回転等) でも無制限に client を作らせない最終バックストップ
-        if (!$this->mcpDcrRegisterGlobalLimiter->create('dcr:global')->consume()->isAccepted()) {
-            $this->logger->warning('MCP DCR rejected: global rate limit', ['ip' => $ip]);
+        // IP 単位を先に消費させる。 拒否時はトークンを消費しない (FixedWindowLimiter は reserve 拒否時に
+        // window へ加算しない) ため、 グローバルを先に消費させると単一 IP が IP 拒否後もグローバル枠を消費し続け、
+        // 1 IP でグローバル枠を食い潰して全クライアントを締め出せてしまう。 IP を先に判定すればその影響は IP 上限に収まる。
+        if (!$this->mcpDcrRegisterLimiter->create('dcr:'.$ip)->consume()->isAccepted()) {
+            $this->logger->warning('MCP DCR rejected: per-IP rate limit', ['ip' => $ip]);
 
             return $this->error('rate_limited', 'Too many registration requests', Response::HTTP_TOO_MANY_REQUESTS);
         }
-        if (!$this->mcpDcrRegisterLimiter->create('dcr:'.$ip)->consume()->isAccepted()) {
-            $this->logger->warning('MCP DCR rejected: per-IP rate limit', ['ip' => $ip]);
+        // グローバル上限: IP 偽装 (X-Forwarded-For 回転等) でも無制限に client を作らせない最終バックストップ
+        if (!$this->mcpDcrRegisterGlobalLimiter->create('dcr:global')->consume()->isAccepted()) {
+            $this->logger->warning('MCP DCR rejected: global rate limit', ['ip' => $ip]);
 
             return $this->error('rate_limited', 'Too many registration requests', Response::HTTP_TOO_MANY_REQUESTS);
         }

--- a/Controller/WellKnownController.php
+++ b/Controller/WellKnownController.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Controller;
+
+use Eccube\Controller\AbstractController;
+use Plugin\Api44\Service\OAuthMetadataBuilder;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * MCP クライアントが認可方法を自動発見するための公開メタデータ (RFC 9728 / RFC 8414)。
+ *
+ * 認証不要 (ApiExtension の prepend で `^/\.well-known/oauth-` を security:false にする)。
+ * 中身は「認可サーバの場所」の宣言のみで秘密を含まない。
+ */
+class WellKnownController extends AbstractController
+{
+    public function __construct(
+        private readonly OAuthMetadataBuilder $metadataBuilder,
+    ) {
+    }
+
+    #[Route(path: '/.well-known/oauth-protected-resource', name: 'mcp_well_known_protected_resource', methods: ['GET'])]
+    public function protectedResource(): JsonResponse
+    {
+        return $this->metadata($this->metadataBuilder->protectedResourceMetadata());
+    }
+
+    #[Route(path: '/.well-known/oauth-authorization-server', name: 'mcp_well_known_authorization_server', methods: ['GET'])]
+    public function authorizationServer(): JsonResponse
+    {
+        return $this->metadata($this->metadataBuilder->authorizationServerMetadata());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function metadata(array $data): JsonResponse
+    {
+        $response = new JsonResponse($data);
+        // メタデータの URL は実行時の Host から組み立てるため、 共有キャッシュに載せると Host 詐称時に
+        // 汚染レスポンスが他者へ配信され得る。 キャッシュ汚染の増幅を断つため no-store にする
+        // (本番では加えて TRUSTED_HOSTS の設定が前提)。
+        $response->headers->set('Cache-Control', 'no-store');
+        $response->headers->set('Vary', 'Host');
+
+        return $response;
+    }
+}

--- a/DependencyInjection/ApiExtension.php
+++ b/DependencyInjection/ApiExtension.php
@@ -30,10 +30,20 @@ class ApiExtension extends Extension implements PrependExtensionInterface
                 $names = array_keys($security['firewalls']);
                 $replaced = [];
                 foreach ($names as $name) {
-                    // adminの前にapiを追加する
+                    // adminの前にapi / mcpを追加する
                     if ($name === 'admin') {
                         $replaced['api'] = [
                             'pattern' => '^/api',
+                            'security' => true,
+                            'stateless' => true,
+                            'oauth2' => true,
+                            'provider' => 'member_provider',
+                        ];
+                        // MCP サーバ (本体同梱) 用の OAuth2 firewall。
+                        // ^/<admin_route>/mcp を admin より前に置き、 ステートレスな Bearer 認証で処理する。
+                        // 認可は領域別 read scope (mcp:product:read 等) で行い、 本体側 Tool の IsGranted と AND 評価。
+                        $replaced['mcp'] = [
+                            'pattern' => '^/%eccube_admin_route%/mcp',
                             'security' => true,
                             'stateless' => true,
                             'oauth2' => true,

--- a/DependencyInjection/ApiExtension.php
+++ b/DependencyInjection/ApiExtension.php
@@ -73,6 +73,14 @@ class ApiExtension extends Extension implements PrependExtensionInterface
         }
 
         $extensionConfigsRefl->setValue($container, $extensionConfigs);
+
+        // PKCE(S256) を public クライアントに必須化する。 league の既定は true だが、 将来の既定変更で
+        // 静かに無効化されないよう明示的に固定する (secret を持たない public クライアントの認可コード横取り対策)。
+        $container->prependExtensionConfig('league_oauth2_server', [
+            'authorization_server' => [
+                'require_code_challenge_for_public_clients' => true,
+            ],
+        ]);
     }
 
     public function load(array $configs, ContainerBuilder $container)

--- a/DependencyInjection/ApiExtension.php
+++ b/DependencyInjection/ApiExtension.php
@@ -32,6 +32,13 @@ class ApiExtension extends Extension implements PrependExtensionInterface
                 foreach ($names as $name) {
                     // adminの前にapi / mcpを追加する
                     if ($name === 'admin') {
+                        // OAuth ディスカバリの公開エンドポイント。 認証不要 (メタデータは「場所の宣言」のみで秘密を含まない)。
+                        // 実在する 2 つの well-known と /register に**完全一致**で限定し、 他パスを公開化しない
+                        // (前方一致だと /.well-known/oauth-anything 等が無意図に公開される)。
+                        $replaced['mcp_oauth_public'] = [
+                            'pattern' => '^/(\.well-known/oauth-(protected-resource|authorization-server)|register)$',
+                            'security' => false,
+                        ];
                         $replaced['api'] = [
                             'pattern' => '^/api',
                             'security' => true,
@@ -42,12 +49,14 @@ class ApiExtension extends Extension implements PrependExtensionInterface
                         // MCP サーバ (本体同梱) 用の OAuth2 firewall。
                         // ^/<admin_route>/mcp を admin より前に置き、 ステートレスな Bearer 認証で処理する。
                         // 認可は領域別 read scope (mcp:product:read 等) で行い、 本体側 Tool の IsGranted と AND 評価。
+                        // 401 は entry_point で RFC 9728 の resource_metadata 付き WWW-Authenticate を返す (自動ディスカバリ)。
                         $replaced['mcp'] = [
                             'pattern' => '^/%eccube_admin_route%/mcp',
                             'security' => true,
                             'stateless' => true,
                             'oauth2' => true,
                             'provider' => 'member_provider',
+                            'entry_point' => 'Plugin\Api44\Security\McpAuthenticationEntryPoint',
                         ];
                         unset($security['firewalls']['admin']['form_login']['csrf_token_generator']);
                         unset($security['firewalls']['admin']['anonymous']);

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -147,8 +147,20 @@ class ApiCompilerPass implements CompilerPassInterface
         $projectDir = $container->getParameter('kernel.project_dir');
         $oauthConfig = $container->getExtensionConfig('league_oauth2_server');
         $oauthConfig = $container->resolveEnvPlaceholders($oauthConfig, true);
-        $privateKey = str_replace('%%kernel.project_dir%%', $projectDir, $oauthConfig[0]['authorization_server']['private_key']);
-        $publicKey = str_replace('%%kernel.project_dir%%', $projectDir, $oauthConfig[0]['resource_server']['public_key']);
+
+        // getExtensionConfig は prepend 順 (先頭=最後に prepend された断片) の配列を返す。 鍵パスを持つ断片が
+        // 先頭とは限らない (別の prepend が鍵を含まない断片を先頭に積むことがある) ため、 位置を仮定せず探す。
+        $privateKey = null;
+        $publicKey = null;
+        foreach ($oauthConfig as $fragment) {
+            $privateKey ??= $fragment['authorization_server']['private_key'] ?? null;
+            $publicKey ??= $fragment['resource_server']['public_key'] ?? null;
+        }
+        if (null === $privateKey || null === $publicKey) {
+            return;
+        }
+        $privateKey = str_replace('%%kernel.project_dir%%', (string) $projectDir, (string) $privateKey);
+        $publicKey = str_replace('%%kernel.project_dir%%', (string) $projectDir, (string) $publicKey);
 
         if (!$this->isRSAKeyContent($privateKey) && !file_exists($privateKey)
             && !$this->isRSAKeyContent($publicKey) && !file_exists($publicKey)) {

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -86,7 +86,14 @@ class ApiCompilerPass implements CompilerPassInterface
 
         $adminRoute = (string) $container->getParameter('eccube_admin_route');
         $matcher = (new Definition(PathRequestMatcher::class, ['^/'.$adminRoute.'/mcp']))->setPublic(false);
-        $roles = array_values(array_unique(McpToolScopeMap::MAP));
+        // 本体 McpToolScopeMap と同じ read scope role。 本体を持たない環境 (Api44 単体の phpstan/CI) では
+        // MAP の型が解決できず解析が落ちるため直書きする。 領域を増やしたら本体 McpToolScopeMap と同期する。
+        $roles = [
+            'ROLE_OAUTH2_MCP:PRODUCT:READ',
+            'ROLE_OAUTH2_MCP:ORDER:READ',
+            'ROLE_OAUTH2_MCP:CUSTOMER:READ',
+            'ROLE_OAUTH2_MCP:PLUGIN:READ',
+        ];
 
         $accessMap = $container->getDefinition('security.access_map');
         $calls = $accessMap->getMethodCalls();

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -13,6 +13,7 @@
 
 namespace Plugin\Api44\DependencyInjection\Compiler;
 
+use Eccube\Service\Mcp\McpToolScopeMap;
 use Plugin\Api44\GraphQL\AllowList;
 use Plugin\Api44\GraphQL\Mutation;
 use Plugin\Api44\GraphQL\Query;
@@ -21,7 +22,9 @@ use Plugin\Api44\Service\WebHookEvents;
 use Plugin\Api44\Service\WebHookTrigger;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 
 class ApiCompilerPass implements CompilerPassInterface
 {
@@ -37,6 +40,7 @@ class ApiCompilerPass implements CompilerPassInterface
         $this->configureAllowList($container);
         $this->configureKeyPair($container);
         $this->configureSchema($container);
+        $this->configureMcpAccessControl($container);
 
         $plugins = $container->getParameter('eccube.plugins.enabled');
         if (!in_array('Api44', $plugins)) {
@@ -62,6 +66,31 @@ class ApiCompilerPass implements CompilerPassInterface
                 $mutationsServiceDef->addMethodCall('append', [$definition]);
             }
         }
+    }
+
+    /**
+     * `/admin/mcp` に「最低 1 つの mcp read scope」 を要求する access_control を、 core の
+     * `^/<admin> → ROLE_ADMIN` より前 (AccessMap は先頭一致) に構造的に挿入する。
+     *
+     * config prepend で足すと、 core が prependExtensionConfig(先頭 unshift) で入れる `^/<admin>`
+     * ルールに shadow され no-op になる。 そこで SecurityExtension が組んだ security.access_map の
+     * add() 呼び出し列の先頭へ直接差し込む。 role は本体 McpToolScopeMap を唯一のソースにする。
+     */
+    private function configureMcpAccessControl(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('security.access_map')) {
+            return;
+        }
+
+        $adminRoute = (string) $container->getParameter('eccube_admin_route');
+        $matcher = (new Definition(PathRequestMatcher::class, ['^/'.$adminRoute.'/mcp']))->setPublic(false);
+        $roles = array_values(array_unique(McpToolScopeMap::MAP));
+
+        $accessMap = $container->getDefinition('security.access_map');
+        $calls = $accessMap->getMethodCalls();
+        // AccessMap は先頭一致。 core の ^/<admin> → ROLE_ADMIN より前に置くため先頭へ unshift する。
+        array_unshift($calls, ['add', [$matcher, $roles, null]]);
+        $accessMap->setMethodCalls($calls);
     }
 
     private function configureTrigger(ContainerBuilder $container): void

--- a/DependencyInjection/Compiler/ApiCompilerPass.php
+++ b/DependencyInjection/Compiler/ApiCompilerPass.php
@@ -78,7 +78,9 @@ class ApiCompilerPass implements CompilerPassInterface
      */
     private function configureMcpAccessControl(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('security.access_map')) {
+        // MCP 本体 (McpToolScopeMap) を持たない ec-cube では保護すべき /admin/mcp ツールが無いので何もしない。
+        // Api44 単体を素の本体に載せる構成 (MCP 未搭載) での class-not-found fatal を避ける。
+        if (!class_exists(McpToolScopeMap::class) || !$container->hasDefinition('security.access_map')) {
             return;
         }
 

--- a/Entity/DcrClient.php
+++ b/Entity/DcrClient.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Entity\AbstractEntity;
+use Plugin\Api44\Repository\DcrClientRepository;
+
+/**
+ * 動的クライアント登録 (DCR) で作成した OAuth クライアントの作成時刻を追跡するメタデータ。
+ *
+ * league の oauth2_client には作成時刻が無いため、 死蔵クライアント掃除の grace 判定
+ * (登録直後の in-flight な client を消さない) に使う作成時刻をここで保持する。
+ * 認証の正本は league の Client (oauth2_client)。 本エンティティはその識別子を参照するだけ。
+ */
+#[ORM\Table(name: 'plg_api_dcr_client')]
+#[ORM\Entity(repositoryClass: DcrClientRepository::class)]
+class DcrClient extends AbstractEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Column(name: 'id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    /**
+     * @var string league Client の識別子 (oauth2_client.identifier)。 掃除対象の特定に使う
+     */
+    #[ORM\Column(name: 'client_identifier', type: 'string', length: 32, unique: true)]
+    private string $clientIdentifier;
+
+    /**
+     * @var \DateTime DCR 登録時刻 (grace 判定の基準)
+     */
+    #[ORM\Column(name: 'create_date', type: 'datetimetz')]
+    private \DateTime $createDate;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getClientIdentifier(): string
+    {
+        return $this->clientIdentifier;
+    }
+
+    public function setClientIdentifier(string $clientIdentifier): void
+    {
+        $this->clientIdentifier = $clientIdentifier;
+    }
+
+    public function getCreateDate(): \DateTime
+    {
+        return $this->createDate;
+    }
+
+    public function setCreateDate(\DateTime $createDate): void
+    {
+        $this->createDate = $createDate;
+    }
+}

--- a/Entity/McpToken.php
+++ b/Entity/McpToken.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Eccube\Entity\AbstractEntity;
+use Plugin\Api44\Repository\McpTokenRepository;
+
+/**
+ * 管理画面から発行した MCP 用アクセストークンの表示用メタデータ。
+ *
+ * 認証・失効の正本は league の AccessToken (oauth2_access_token)。 本エンティティは
+ * オーナーが一覧で識別するためのラベル等を保持し、 league トークンの識別子 (jti) を
+ * `token_identifier` で参照して失効操作と紐付ける。 JWT 本体は保存しない (発行時のみ表示)。
+ */
+#[ORM\Table(name: 'plg_api_mcp_token')]
+#[ORM\Entity(repositoryClass: McpTokenRepository::class)]
+class McpToken extends AbstractEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Column(name: 'id', type: 'integer', options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
+
+    /**
+     * @var string league AccessToken の識別子 (JWT の jti)。 失効操作の連携キー
+     */
+    #[ORM\Column(name: 'token_identifier', type: 'string', length: 80, unique: true)]
+    private string $tokenIdentifier;
+
+    /**
+     * @var string オーナーが付ける表示用ラベル
+     */
+    #[ORM\Column(name: 'label', type: 'string', length: 255)]
+    private string $label;
+
+    /**
+     * @var list<string> 付与した scope (mcp:*:read)
+     */
+    #[ORM\Column(name: 'scopes', type: 'simple_array')]
+    private array $scopes = [];
+
+    /**
+     * @var int 発行した Member の ID
+     */
+    #[ORM\Column(name: 'member_id', type: 'integer', options: ['unsigned' => true])]
+    private int $memberId;
+
+    /**
+     * @var \DateTime 有効期限
+     */
+    #[ORM\Column(name: 'expire_date', type: 'datetimetz')]
+    private \DateTime $expireDate;
+
+    /**
+     * @var \DateTime
+     */
+    #[ORM\Column(name: 'create_date', type: 'datetimetz')]
+    private \DateTime $createDate;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTokenIdentifier(): string
+    {
+        return $this->tokenIdentifier;
+    }
+
+    public function setTokenIdentifier(string $tokenIdentifier): void
+    {
+        $this->tokenIdentifier = $tokenIdentifier;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getScopes(): array
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    public function setScopes(array $scopes): void
+    {
+        $this->scopes = $scopes;
+    }
+
+    public function getMemberId(): int
+    {
+        return $this->memberId;
+    }
+
+    public function setMemberId(int $memberId): void
+    {
+        $this->memberId = $memberId;
+    }
+
+    public function getExpireDate(): \DateTime
+    {
+        return $this->expireDate;
+    }
+
+    public function setExpireDate(\DateTime $expireDate): void
+    {
+        $this->expireDate = $expireDate;
+    }
+
+    public function getCreateDate(): \DateTime
+    {
+        return $this->createDate;
+    }
+
+    public function setCreateDate(\DateTime $createDate): void
+    {
+        $this->createDate = $createDate;
+    }
+}

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -69,7 +69,7 @@ class AuthorizationResponseIssListener
         // issuer は AS メタデータと同一値 (OAuthMetadataBuilder::baseUrl)。 正しさは TRUSTED_HOSTS 設定に依存する (本番必須)
         $issuer = $this->metadata->baseUrl();
         if ('' === $issuer) {
-            // oauth2_authorize 到達後は現在リクエストが必ず存在するため、 ここは防御的 (実質到達しない)
+            // baseUrl() は RequestStack が空のとき '' を返す。 空 iss を付けた不正な認可応答を返さないため付与しない
             return;
         }
 

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -62,9 +62,6 @@ class AuthorizationResponseIssListener
         if (!$hasAuthResponse) {
             return;
         }
-        if (isset($queryParams['iss']) || isset($fragmentParams['iss'])) {
-            return;
-        }
 
         // issuer は AS メタデータと同一値 (OAuthMetadataBuilder::baseUrl)。 正しさは TRUSTED_HOSTS 設定に依存する (本番必須)
         $issuer = $this->metadata->baseUrl();
@@ -73,8 +70,56 @@ class AuthorizationResponseIssListener
             return;
         }
 
-        // code/error が乗るコンポーネント (成功=query / fragment エラー=fragment) は末尾かつ非空なので、
-        // 末尾に '&iss=' を足せば同一コンポーネントに収まる。
-        $response->headers->set('Location', $location.'&iss='.rawurlencode($issuer));
+        // league は iss を出さないため、 応答に既にある iss は redirect_uri 由来 (= client 制御) で信用できない。
+        // mix-up 対策の iss は AS が強制するものなので (RFC 9207)、 既存を除去してから AS の issuer で上書きする。
+        unset($queryParams['iss'], $fragmentParams['iss']);
+
+        // code/error が乗るコンポーネント (成功=query / fragment エラー=fragment) に iss を載せる。
+        if (isset($queryParams['code']) || isset($queryParams['error'])) {
+            $queryParams['iss'] = $issuer;
+        } else {
+            $fragmentParams['iss'] = $issuer;
+        }
+
+        $response->headers->set('Location', $this->rebuildUrl($parts, $queryParams, $fragmentParams));
+    }
+
+    /**
+     * parse_url の各パーツと query / fragment のパラメータから Location URL を組み立て直す。
+     *
+     * @param array<string, mixed> $parts          parse_url の結果
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $fragmentParams
+     */
+    private function rebuildUrl(array $parts, array $queryParams, array $fragmentParams): string
+    {
+        $url = '';
+        if (isset($parts['scheme'])) {
+            $url .= (string) $parts['scheme'].'://';
+        }
+        if (isset($parts['user'])) {
+            $url .= (string) $parts['user'];
+            if (isset($parts['pass'])) {
+                $url .= ':'.(string) $parts['pass'];
+            }
+            $url .= '@';
+        }
+        if (isset($parts['host'])) {
+            $url .= (string) $parts['host'];
+        }
+        if (isset($parts['port'])) {
+            $url .= ':'.(string) $parts['port'];
+        }
+        if (isset($parts['path'])) {
+            $url .= (string) $parts['path'];
+        }
+        if ([] !== $queryParams) {
+            $url .= '?'.http_build_query($queryParams);
+        }
+        if ([] !== $fragmentParams) {
+            $url .= '#'.http_build_query($fragmentParams);
+        }
+
+        return $url;
     }
 }

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\EventListener;
+
+use Plugin\Api44\Service\OAuthMetadataBuilder;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * RFC 9207: 認可応答 (oauth2_authorize の redirect) に `iss` パラメータを付与する。
+ *
+ * league/oauth2-server は認可コード応答の生成にフックを持たず iss を出さないため、
+ * 認可応答の Location ヘッダに後付けする。 issuer は AS メタデータの issuer と同一値
+ * (OAuthMetadataBuilder::baseUrl) を使い、 クライアントの検証と齟齬を出さない。
+ *
+ * 付与対象は「クライアントへ返す認可応答」(query に code または error を持つ redirect) のみ。
+ * 未ログイン時のログイン画面 redirect 等には付与しない。
+ */
+class AuthorizationResponseIssListener
+{
+    public function __construct(private readonly OAuthMetadataBuilder $metadata)
+    {
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+        if ('oauth2_authorize' !== $event->getRequest()->attributes->get('_route')) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $location = $response->headers->get('Location');
+        if (null === $location) {
+            return;
+        }
+
+        // 認可応答 (client への code / error redirect) だけに付与する。 ログイン redirect 等は対象外
+        parse_str((string) parse_url($location, PHP_URL_QUERY), $params);
+        if (!isset($params['code']) && !isset($params['error'])) {
+            return;
+        }
+        if (isset($params['iss'])) {
+            return;
+        }
+
+        $issuer = $this->metadata->baseUrl();
+        if ('' === $issuer) {
+            return;
+        }
+
+        $separator = str_contains($location, '?') ? '&' : '?';
+        $response->headers->set('Location', $location.$separator.'iss='.rawurlencode($issuer));
+    }
+}

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
  * 認可応答の Location ヘッダに後付けする。 issuer は AS メタデータの issuer と同一値
  * (OAuthMetadataBuilder::baseUrl) を使い、 クライアントの検証と齟齬を出さない。
  *
- * 付与対象は「クライアントへ返す認可応答」(query に code または error を持つ redirect) のみ。
+ * 付与対象は「クライアントへ返す認可応答」(query または fragment に code または error を持つ redirect) のみ。
  * 未ログイン時のログイン画面 redirect 等には付与しない。
  */
 class AuthorizationResponseIssListener

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -53,13 +53,18 @@ class AuthorizationResponseIssListener
         if (false === $parts) {
             return;
         }
-        parse_str($parts['query'] ?? '', $queryParams);
-        parse_str($parts['fragment'] ?? '', $fragmentParams);
+        $rawQuery = $parts['query'] ?? '';
+        $rawFragment = $parts['fragment'] ?? '';
+
+        // 判定にのみ parse_str を使う。 parse_str はパラメータ名の '.'・空白を '_' に変換し重複キーを畳むため、
+        // redirect_uri 由来のクエリを保つには組み立てに使えない。 iss の除去・追記は生文字列側で行う。
+        parse_str($rawQuery, $queryParams);
+        parse_str($rawFragment, $fragmentParams);
 
         // 認可応答 (client への code / error redirect) だけに付与する。 ログイン redirect 等は対象外
-        $hasAuthResponse = isset($queryParams['code']) || isset($queryParams['error'])
-            || isset($fragmentParams['code']) || isset($fragmentParams['error']);
-        if (!$hasAuthResponse) {
+        $codeInQuery = isset($queryParams['code']) || isset($queryParams['error']);
+        $codeInFragment = isset($fragmentParams['code']) || isset($fragmentParams['error']);
+        if (!$codeInQuery && !$codeInFragment) {
             return;
         }
 
@@ -71,27 +76,24 @@ class AuthorizationResponseIssListener
         }
 
         // league は iss を出さないため、 応答に既にある iss は redirect_uri 由来 (= client 制御) で信用できない。
-        // mix-up 対策の iss は AS が強制するものなので (RFC 9207)、 既存を除去してから AS の issuer で上書きする。
-        unset($queryParams['iss'], $fragmentParams['iss']);
-
-        // code/error が乗るコンポーネント (成功=query / fragment エラー=fragment) に iss を載せる。
-        if (isset($queryParams['code']) || isset($queryParams['error'])) {
-            $queryParams['iss'] = $issuer;
+        // mix-up 対策の iss は AS が強制する (RFC 9207) ため、 code/error が乗るコンポーネントの生文字列から
+        // 既存 iss を除去し、 AS の issuer を追記する。 他のパラメータは生文字列のまま保つ。
+        if ($codeInQuery) {
+            $rawQuery = $this->appendParam($this->stripParam($rawQuery, 'iss'), 'iss', $issuer);
         } else {
-            $fragmentParams['iss'] = $issuer;
+            $rawFragment = $this->appendParam($this->stripParam($rawFragment, 'iss'), 'iss', $issuer);
         }
 
-        $response->headers->set('Location', $this->rebuildUrl($parts, $queryParams, $fragmentParams));
+        $response->headers->set('Location', $this->rebuildUrl($parts, $rawQuery, $rawFragment));
     }
 
     /**
-     * parse_url の各パーツと query / fragment のパラメータから Location URL を組み立て直す。
+     * parse_url の各パーツと query / fragment の生文字列から Location URL を組み立て直す。
+     * query / fragment は元の文字列をそのまま連結し、 redirect_uri 由来のパラメータを書き換えない。
      *
-     * @param array<string, mixed> $parts          parse_url の結果
-     * @param array<string, mixed> $queryParams
-     * @param array<string, mixed> $fragmentParams
+     * @param array<string, mixed> $parts parse_url の結果
      */
-    private function rebuildUrl(array $parts, array $queryParams, array $fragmentParams): string
+    private function rebuildUrl(array $parts, string $query, string $fragment): string
     {
         $url = '';
         if (isset($parts['scheme'])) {
@@ -113,13 +115,48 @@ class AuthorizationResponseIssListener
         if (isset($parts['path'])) {
             $url .= (string) $parts['path'];
         }
-        if ([] !== $queryParams) {
-            $url .= '?'.http_build_query($queryParams);
+        if ('' !== $query) {
+            $url .= '?'.$query;
         }
-        if ([] !== $fragmentParams) {
-            $url .= '#'.http_build_query($fragmentParams);
+        if ('' !== $fragment) {
+            $url .= '#'.$fragment;
         }
 
         return $url;
+    }
+
+    /**
+     * query / fragment の生文字列から、 指定名のパラメータを除去する。
+     * 名前比較のためキー部のみ rawurldecode する (値・他パラメータは触らない)。
+     */
+    private function stripParam(string $raw, string $name): string
+    {
+        if ('' === $raw) {
+            return '';
+        }
+        $kept = [];
+        foreach (explode('&', $raw) as $segment) {
+            if ('' === $segment) {
+                continue;
+            }
+            $eq = strpos($segment, '=');
+            $key = false === $eq ? $segment : substr($segment, 0, $eq);
+            if ($name === rawurldecode($key)) {
+                continue;
+            }
+            $kept[] = $segment;
+        }
+
+        return implode('&', $kept);
+    }
+
+    /**
+     * query / fragment の生文字列に name=rawurlencode(value) を追記する。
+     */
+    private function appendParam(string $raw, string $name, string $value): string
+    {
+        $encoded = $name.'='.rawurlencode($value);
+
+        return '' === $raw ? $encoded : $raw.'&'.$encoded;
     }
 }

--- a/EventListener/AuthorizationResponseIssListener.php
+++ b/EventListener/AuthorizationResponseIssListener.php
@@ -47,21 +47,34 @@ class AuthorizationResponseIssListener
             return;
         }
 
-        // 認可応答 (client への code / error redirect) だけに付与する。 ログイン redirect 等は対象外
-        parse_str((string) parse_url($location, PHP_URL_QUERY), $params);
-        if (!isset($params['code']) && !isset($params['error'])) {
+        // response_type=code の成功応答は code を query に持つ。 league はエラー応答を、 登録 redirect_uri に
+        // '#' が含まれる場合は fragment に出す。 RFC 9207 は code/error が乗る側に iss を付けるため両方を見る。
+        $parts = parse_url($location);
+        if (false === $parts) {
             return;
         }
-        if (isset($params['iss'])) {
+        parse_str($parts['query'] ?? '', $queryParams);
+        parse_str($parts['fragment'] ?? '', $fragmentParams);
+
+        // 認可応答 (client への code / error redirect) だけに付与する。 ログイン redirect 等は対象外
+        $hasAuthResponse = isset($queryParams['code']) || isset($queryParams['error'])
+            || isset($fragmentParams['code']) || isset($fragmentParams['error']);
+        if (!$hasAuthResponse) {
+            return;
+        }
+        if (isset($queryParams['iss']) || isset($fragmentParams['iss'])) {
             return;
         }
 
+        // issuer は AS メタデータと同一値 (OAuthMetadataBuilder::baseUrl)。 正しさは TRUSTED_HOSTS 設定に依存する (本番必須)
         $issuer = $this->metadata->baseUrl();
         if ('' === $issuer) {
+            // oauth2_authorize 到達後は現在リクエストが必ず存在するため、 ここは防御的 (実質到達しない)
             return;
         }
 
-        $separator = str_contains($location, '?') ? '&' : '?';
-        $response->headers->set('Location', $location.$separator.'iss='.rawurlencode($issuer));
+        // code/error が乗るコンポーネント (成功=query / fragment エラー=fragment) は末尾かつ非空なので、
+        // 末尾に '&iss=' を足せば同一コンポーネントに収まる。
+        $response->headers->set('Location', $location.'&iss='.rawurlencode($issuer));
     }
 }

--- a/Form/Type/Admin/McpTokenType.php
+++ b/Form/Type/Admin/McpTokenType.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Form\Type\Admin;
+
+use Plugin\Api44\Service\McpTokenService;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * MCP トークン発行フォーム。 ラベル・MCP scope・有効期限を入力する。
+ * scope の選択肢は MCP の領域別 read のみ (発行できる権限を構造的に制限する)。
+ */
+class McpTokenType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $scopeChoices = array_combine(McpTokenService::AVAILABLE_SCOPES, McpTokenService::AVAILABLE_SCOPES);
+
+        $builder
+            ->add('label', TextType::class, [
+                'mapped' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => 255]),
+                ],
+            ])
+            ->add('scopes', ChoiceType::class, [
+                'mapped' => false,
+                'choices' => $scopeChoices,
+                'expanded' => true,
+                'multiple' => true,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                ],
+            ])
+            ->add('expire', ChoiceType::class, [
+                'mapped' => false,
+                'choices' => [
+                    '30日' => 30,
+                    '90日' => 90,
+                    '180日' => 180,
+                    '365日' => 365,
+                ],
+                'data' => 30,
+                'expanded' => false,
+                'multiple' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Choice(['choices' => [30, 90, 180, 365]]),
+                ],
+            ]);
+    }
+}

--- a/Form/Type/Admin/McpTokenType.php
+++ b/Form/Type/Admin/McpTokenType.php
@@ -29,6 +29,9 @@ class McpTokenType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $scopeChoices = array_combine(McpTokenService::AVAILABLE_SCOPES, McpTokenService::AVAILABLE_SCOPES);
+        // 有効日数は McpTokenService を単一のソースにする (choices と Assert\Choice の二重管理を避ける)。
+        $expireDays = McpTokenService::AVAILABLE_EXPIRE_DAYS;
+        $expireChoices = array_combine(array_map(static fn (int $d): string => $d.'日', $expireDays), $expireDays);
 
         $builder
             ->add('label', TextType::class, [
@@ -49,18 +52,13 @@ class McpTokenType extends AbstractType
             ])
             ->add('expire', ChoiceType::class, [
                 'mapped' => false,
-                'choices' => [
-                    '30日' => 30,
-                    '90日' => 90,
-                    '180日' => 180,
-                    '365日' => 365,
-                ],
-                'data' => 30,
+                'choices' => $expireChoices,
+                'data' => $expireDays[0],
                 'expanded' => false,
                 'multiple' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Choice(['choices' => [30, 90, 180, 365]]),
+                    new Assert\Choice(['choices' => $expireDays]),
                 ],
             ]);
     }

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -18,6 +18,10 @@ use Eccube\Entity\AuthorityRole;
 use Eccube\Entity\Master\Authority;
 use Eccube\Plugin\AbstractPluginManager;
 use Eccube\Repository\AuthorityRoleRepository;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Service\McpTokenService;
 use Psr\Container\ContainerInterface;
 
 class PluginManager extends AbstractPluginManager
@@ -30,6 +34,7 @@ class PluginManager extends AbstractPluginManager
     public function enable(array $meta, ContainerInterface $container): void
     {
         $this->createAuthorityRole($container);
+        $this->createMcpPatClient($container);
     }
 
     /**
@@ -53,6 +58,33 @@ class PluginManager extends AbstractPluginManager
         $AuthorityRole->setDenyUrl($this->denyUrl);
 
         $entityManager->persist($AuthorityRole);
+        $entityManager->flush();
+    }
+
+    /**
+     * MCP トークン (PAT) 発行に使う内部クライアントを冪等生成する。
+     * league の ClientManager は private のため EntityManager 経由で永続化する。
+     */
+    private function createMcpPatClient(ContainerInterface $container): void
+    {
+        /** @var EntityManager $entityManager */
+        $entityManager = $container->get('doctrine')->getManager();
+
+        $existing = $entityManager->getRepository(Client::class)
+            ->findOneBy(['identifier' => McpTokenService::CLIENT_IDENTIFIER]);
+        if (null !== $existing) {
+            return;
+        }
+
+        $client = new Client('MCP PAT', McpTokenService::CLIENT_IDENTIFIER, null);
+        $client->setActive(true);
+        $client->setGrants(new Grant('authorization_code'));
+        $client->setScopes(...array_map(
+            static fn (string $scope): Scope => new Scope($scope),
+            McpTokenService::AVAILABLE_SCOPES,
+        ));
+
+        $entityManager->persist($client);
         $entityManager->flush();
     }
 

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -18,10 +18,6 @@ use Eccube\Entity\AuthorityRole;
 use Eccube\Entity\Master\Authority;
 use Eccube\Plugin\AbstractPluginManager;
 use Eccube\Repository\AuthorityRoleRepository;
-use League\Bundle\OAuth2ServerBundle\Model\Client;
-use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
-use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
-use Plugin\Api44\Service\McpTokenService;
 use Psr\Container\ContainerInterface;
 
 class PluginManager extends AbstractPluginManager
@@ -34,7 +30,6 @@ class PluginManager extends AbstractPluginManager
     public function enable(array $meta, ContainerInterface $container): void
     {
         $this->createAuthorityRole($container);
-        $this->createMcpPatClient($container);
     }
 
     /**
@@ -58,33 +53,6 @@ class PluginManager extends AbstractPluginManager
         $AuthorityRole->setDenyUrl($this->denyUrl);
 
         $entityManager->persist($AuthorityRole);
-        $entityManager->flush();
-    }
-
-    /**
-     * MCP トークン (PAT) 発行に使う内部クライアントを冪等生成する。
-     * league の ClientManager は private のため EntityManager 経由で永続化する。
-     */
-    private function createMcpPatClient(ContainerInterface $container): void
-    {
-        /** @var EntityManager $entityManager */
-        $entityManager = $container->get('doctrine')->getManager();
-
-        $existing = $entityManager->getRepository(Client::class)
-            ->findOneBy(['identifier' => McpTokenService::CLIENT_IDENTIFIER]);
-        if (null !== $existing) {
-            return;
-        }
-
-        $client = new Client('MCP PAT', McpTokenService::CLIENT_IDENTIFIER, null);
-        $client->setActive(true);
-        $client->setGrants(new Grant('authorization_code'));
-        $client->setScopes(...array_map(
-            static fn (string $scope): Scope => new Scope($scope),
-            McpTokenService::AVAILABLE_SCOPES,
-        ));
-
-        $entityManager->persist($client);
         $entityManager->flush();
     }
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@
 * SSLサーバー証明書(TLS) は必須
 
 詳しくは [EC-CUBE4 Web API プラグイン 開発ドキュメント](https://doc.ec-cube.net/eccube-api4/) をご確認ください。
+
+## MCP サーバ利用時のセキュリティ設定
+
+MCP サーバ機能を本番で利用する場合、 環境変数 `TRUSTED_HOSTS` と `TRUSTED_PROXIES` の設定が必須です。
+
+OAuth ディスカバリの `resource_metadata` などの URL はリクエストの Host 名から組み立てます。
+`TRUSTED_HOSTS` が未設定だと Host ヘッダを偽装され、 クライアントを攻撃者の認可サーバへ誘導される恐れがあります。
+
+- `TRUSTED_HOSTS` — 公開ドメインに一致する正規表現（例: `^(www\.)?example\.com$`）
+- `TRUSTED_PROXIES` — リバースプロキシ配下ではプロキシの IP レンジ
+
+未設定のまま本番で MCP メタデータを配信すると警告ログが出力されます。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### 動作確認環境
 
-* PHP 7.2 or higher
+* PHP 8.2 or higher
 * PostgreSQL or MySQL
 * SSLサーバー証明書(TLS) は必須
 

--- a/Repository/DcrClientRepository.php
+++ b/Repository/DcrClientRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Eccube\Repository\AbstractRepository;
+use Plugin\Api44\Entity\DcrClient;
+
+/**
+ * @extends AbstractRepository<DcrClient>
+ */
+class DcrClientRepository extends AbstractRepository
+{
+    public function __construct(ManagerRegistry $registry, string $entityClass = DcrClient::class)
+    {
+        parent::__construct($registry, $entityClass);
+    }
+
+    /**
+     * 指定時刻より前に登録された DCR クライアントを返す (grace を過ぎた掃除候補)。
+     *
+     * 追跡レコードのある client のみが対象。 機能導入前や記録漏れの client は作成時刻が無く対象外。
+     *
+     * @return list<DcrClient>
+     */
+    public function findRegisteredBefore(\DateTimeInterface $threshold): array
+    {
+        return $this->createQueryBuilder('d')
+            ->where('d.createDate < :threshold')
+            ->setParameter('threshold', $threshold)
+            ->orderBy('d.createDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/Repository/McpTokenRepository.php
+++ b/Repository/McpTokenRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Eccube\Repository\AbstractRepository;
+use Plugin\Api44\Entity\McpToken;
+
+/**
+ * @extends AbstractRepository<McpToken>
+ */
+class McpTokenRepository extends AbstractRepository
+{
+    public function __construct(ManagerRegistry $registry, string $entityClass = McpToken::class)
+    {
+        parent::__construct($registry, $entityClass);
+    }
+
+    /**
+     * 発行済み MCP トークンを新しい順に返す (一覧表示用)。
+     *
+     * @return list<McpToken>
+     */
+    public function findAllOrderByCreateDate(): array
+    {
+        return $this->findBy([], ['createDate' => 'DESC']);
+    }
+}

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -71,6 +71,10 @@ services:
     Plugin\Api44\Security\McpAuthenticationEntryPoint:
         autowire: true
 
+    # DCR 死蔵クライアント掃除 (CleanupDcrClientsCommand から利用)
+    Plugin\Api44\Service\DcrClientCleaner:
+        autowire: true
+
     Plugin\Api44\EventListener\UserResolveListener:
         arguments:
             - '@Eccube\Security\Core\User\MemberProvider'

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -3,6 +3,21 @@ parameters:
     env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY): '%kernel.project_dir%/app/PluginData/Api44/oauth/public.key'
     env(ECCUBE_OAUTH2_ENCRYPTION_KEY): '<change.me>'
 
+framework:
+    rate_limiter:
+        # 公開 DCR (/register) の濫用・死蔵クライアント量産を抑止する IP 単位の制限
+        mcp_dcr_register:
+            policy: 'fixed_window'
+            limit: 20
+            interval: '1 hour'
+            cache_pool: cache.app
+        # IP 偽装 (X-Forwarded-For 回転等) でも無制限に作らせないためのグローバル上限 (バックストップ)
+        mcp_dcr_register_global:
+            policy: 'fixed_window'
+            limit: 200
+            interval: '1 hour'
+            cache_pool: cache.app
+
 league_oauth2_server:
     role_prefix: ROLE_OAUTH2_
 
@@ -45,6 +60,16 @@ services:
         autowire: true
         arguments:
             $privateKeyPath: '%env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY)%'
+
+    # OAuth ディスカバリのメタデータ生成 (URL 組み立てを 1 箇所に)
+    Plugin\Api44\Service\OAuthMetadataBuilder:
+        autowire: true
+        arguments:
+            $adminRoute: '%eccube_admin_route%'
+
+    # mcp firewall の entry_point (401 に RFC 9728 resource_metadata を付与)
+    Plugin\Api44\Security\McpAuthenticationEntryPoint:
+        autowire: true
 
     Plugin\Api44\EventListener\UserResolveListener:
         arguments:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -30,7 +30,10 @@ league_oauth2_server:
         public_key: '%env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY)%'
 
     scopes:
-        available: ['read', 'write']
+        # 既存の `read` / `write` は GraphQL 用。 `mcp:*:read` は MCP サーバ機能 (本体同梱) 用の領域別 read scope。
+        # role 変換時はそれぞれ `ROLE_OAUTH2_MCP:PRODUCT:READ` 等 (`role_prefix: ROLE_OAUTH2_` で大文字化)。
+        # GraphQL の認可と MCP の認可を独立させるため名前空間 `mcp:` で分離する。
+        available: ['read', 'write', 'mcp:product:read', 'mcp:order:read', 'mcp:customer:read', 'mcp:plugin:read']
         default: ['read']
 
     persistence:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -40,6 +40,12 @@ league_oauth2_server:
         doctrine: null
 
 services:
+    # MCP トークン発行サービス。 league の manager / EntityManager は autowire、 署名鍵パスのみ bind する
+    Plugin\Api44\Service\McpTokenService:
+        autowire: true
+        arguments:
+            $privateKeyPath: '%env(ECCUBE_OAUTH2_AUTHORIZATION_SERVER_PRIVATE_KEY)%'
+
     Plugin\Api44\EventListener\UserResolveListener:
         arguments:
             - '@Eccube\Security\Core\User\MemberProvider'

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -66,6 +66,7 @@ services:
         autowire: true
         arguments:
             $adminRoute: '%eccube_admin_route%'
+            $kernelEnvironment: '%kernel.environment%'
 
     # mcp firewall の entry_point (401 に RFC 9728 resource_metadata を付与)
     Plugin\Api44\Security\McpAuthenticationEntryPoint:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -75,6 +75,12 @@ services:
     Plugin\Api44\Service\DcrClientCleaner:
         autowire: true
 
+    # RFC 9207: 認可応答の Location に iss を付与する
+    Plugin\Api44\EventListener\AuthorizationResponseIssListener:
+        autowire: true
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+
     Plugin\Api44\EventListener\UserResolveListener:
         arguments:
             - '@Eccube\Security\Core\User\MemberProvider'

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -20,6 +20,10 @@ api:
       scope_tooltip: GraphQL Query requires read, Mutation requires write/write Scope
       scope.read.description: 'Read %shop_name% data'
       scope.write.description: 'Write %shop_name% data'
+      'scope.mcp:product:read.description': 'Read %shop_name% product and stock data'
+      'scope.mcp:order:read.description': 'Read %shop_name% order data'
+      'scope.mcp:customer:read.description': 'Read %shop_name% customer data'
+      'scope.mcp:plugin:read.description': 'Read %shop_name% plugin information'
       redirect_uri: Redirect URI
       redirect_uri_tooltip: You can enter multiple URIs separated by commas
       grant_type: Grant Type

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -34,6 +34,24 @@ api:
       allow__confirm_description: 'Allow this app to:'
       allow: Allow
       deny: Deny
+      api_registration__new: New API client
+      mcp_token.registration__new: New MCP token
+      mcp_token.registration: Issue MCP token
+      mcp_token.management: MCP tokens
+      mcp_token.label: Label
+      mcp_token.label_tooltip: A name describing the token usage (e.g. Claude Desktop home PC)
+      mcp_token.scope: Scope
+      mcp_token.scope_tooltip: Read access to the areas (products, orders, customers, plugins) this token can reference
+      mcp_token.expire: Expiration
+      mcp_token.expire_tooltip: The token becomes unusable after this period (max 365 days)
+      mcp_token.issue: Issue
+      mcp_token.issued_by: Issued by
+      mcp_token.issued_title: MCP token issued
+      mcp_token.issued_warning: This token is shown only once on this screen. Copy and store it securely (it cannot be shown again).
+      mcp_token.revoke: Revoke
+      mcp_token.revoke__confirm_title: Revoke MCP token
+      mcp_token.revoke__confirm_message: Are you sure you want to revoke this token? It will stop working immediately.
+      mcp_token.revoke__not_found: The token to revoke was not found (it may already be revoked or expired). It has been removed from the list.
     webhook:
       management:  WebHook
       registration: WebHook Registration

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -47,7 +47,7 @@ api:
       mcp_token.scope: Scope
       mcp_token.scope_tooltip: Read access to the areas (products, orders, customers, plugins) this token can reference
       mcp_token.expire: Expiration
-      mcp_token.expire_tooltip: The token becomes unusable after this period (max 365 days)
+      mcp_token.expire_tooltip: The token becomes unusable after this period (max 180 days)
       mcp_token.issue: Issue
       mcp_token.issued_by: Issued by
       mcp_token.issued_title: MCP token issued

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -20,6 +20,10 @@ api:
       scope_tooltip: GraphQLのQueryにはread, Mutationにはwrite/writeのScopeが必要
       scope.read.description: '%shop_name%のデータに対する読み取り'
       scope.write.description: '%shop_name%のデータに対する書き込み'
+      'scope.mcp:product:read.description': '%shop_name%の商品・在庫データの読み取り'
+      'scope.mcp:order:read.description': '%shop_name%の注文データの読み取り'
+      'scope.mcp:customer:read.description': '%shop_name%の顧客会員データの読み取り'
+      'scope.mcp:plugin:read.description': '%shop_name%のプラグイン情報の読み取り'
       redirect_uri: リダイレクトURI
       redirect_uri_tooltip: カンマ区切りで複数のURIを入力可能
       grant_type: グラントタイプ

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -34,6 +34,24 @@ api:
       allow__confirm_description: 'このアプリに以下を許可します:'
       allow: 許可する
       deny: 許可しない
+      api_registration__new: API 新規追加
+      mcp_token.registration__new: MCP 新規追加
+      mcp_token.registration: MCP トークン発行
+      mcp_token.management: MCP トークン
+      mcp_token.label: ラベル
+      mcp_token.label_tooltip: 'トークンの用途がわかる名前（例: Claude Desktop 自宅PC）'
+      mcp_token.scope: スコープ
+      mcp_token.scope_tooltip: このトークンで参照できる領域（商品・注文・顧客・プラグイン）の read 権限
+      mcp_token.expire: 有効期限
+      mcp_token.expire_tooltip: 期限を過ぎたトークンは利用できなくなります（最長365日）
+      mcp_token.issue: 発行する
+      mcp_token.issued_by: 発行者
+      mcp_token.issued_title: MCP トークンを発行しました
+      mcp_token.issued_warning: このトークンは今この画面でのみ表示されます。 コピーして安全に保管してください（再表示はできません）。
+      mcp_token.revoke: 失効する
+      mcp_token.revoke__confirm_title: MCP トークンを失効します
+      mcp_token.revoke__confirm_message: このトークンを失効してよろしいですか？ 失効すると即座に利用できなくなります。
+      mcp_token.revoke__not_found: 失効対象のトークンが見つかりませんでした（既に失効・期限切れの可能性）。 一覧からは削除しました。
     webhook:
       management:  WebHook管理
       registration: WebHook登録

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -47,7 +47,7 @@ api:
       mcp_token.scope: スコープ
       mcp_token.scope_tooltip: このトークンで参照できる領域（商品・注文・顧客・プラグイン）の read 権限
       mcp_token.expire: 有効期限
-      mcp_token.expire_tooltip: 期限を過ぎたトークンは利用できなくなります（最長365日）
+      mcp_token.expire_tooltip: 期限を過ぎたトークンは利用できなくなります（最長180日）
       mcp_token.issue: 発行する
       mcp_token.issued_by: 発行者
       mcp_token.issued_title: MCP トークンを発行しました

--- a/Resource/template/admin/OAuth/index.twig
+++ b/Resource/template/admin/OAuth/index.twig
@@ -78,7 +78,8 @@ file that was distributed with this source code.
                     </div>
                 </div>
                 <div id="create-client" class="d-block mb-3">
-                    <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_new') }}">{{ 'admin.common.registration__new'|trans }}</a>
+                    <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_new') }}">{{ 'api.admin.oauth.api_registration__new'|trans }}</a>
+                    <a class="btn btn-ec-regular" href="{{ url('admin_api_mcp_token_new') }}">{{ 'api.admin.oauth.mcp_token.registration__new'|trans }}</a>
                 </div>
                 <div class="card rounded border-0 mb-4">
                     <div class="card-body p-0">
@@ -171,6 +172,72 @@ file that was distributed with this source code.
                         </table>
                     </div>
                 </div>
+
+                {# MCP トークン一覧 #}
+                <div class="d-block mb-2 mt-4">
+                    <span class="fw-bold">{{ 'api.admin.oauth.mcp_token.management'|trans }}</span>
+                </div>
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-body p-0">
+                        <table class="table table-sm" style="table-layout:fixed;">
+                            <thead>
+                            <tr>
+                                <th class="border-top-0 pt-2 pb-2 text-center">{{ 'api.admin.oauth.mcp_token.label'|trans }}</th>
+                                <th class="border-top-0 pt-2 pb-2 text-center">{{ 'api.admin.oauth.mcp_token.scope'|trans }}</th>
+                                <th class="border-top-0 pt-2 pb-2 text-center">{{ 'api.admin.oauth.mcp_token.expire'|trans }}</th>
+                                <th class="border-top-0 pt-2 pb-2 text-center">{{ 'api.admin.oauth.mcp_token.issued_by'|trans }}</th>
+                                <th class="border-top-0 pt-2 pb-2 text-center"></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {% for mcpToken in mcpTokens %}
+                                <tr id="mcp-token-{{ mcpToken.id }}">
+                                    <td class="align-middle text-center ps-3">{{ mcpToken.label }}</td>
+                                    <td class="align-middle text-center">
+                                        {% for scope in mcpToken.scopes %}
+                                            {{ scope }}<br>
+                                        {% endfor %}
+                                    </td>
+                                    <td class="align-middle text-center">{{ mcpToken.expireDate|date('Y-m-d H:i') }}</td>
+                                    <td class="align-middle text-center">#{{ mcpToken.memberId }}</td>
+                                    <td class="align-middle pe-3">
+                                        <div class="text-end">
+                                            <div class="px-1 d-inline-block">
+                                                <div class="d-inline-block mr-2" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.mcp_token.revoke'|trans }}">
+                                                    <a class="btn btn-ec-actionIcon action-delete" data-bs-toggle="modal" data-bs-target="#mcp_token_revoke_{{ mcpToken.id }}">
+                                                        <i class="fa fa-close fa-lg text-secondary" aria-hidden="true"></i>
+                                                    </a>
+                                                </div>
+                                                <div class="modal fade" id="mcp_token_revoke_{{ mcpToken.id }}" tabindex="-1" role="dialog" aria-hidden="true">
+                                                    <div class="modal-dialog" role="document">
+                                                        <div class="modal-content">
+                                                            <div class="modal-header">
+                                                                <h5 class="modal-title fw-bold">{{ 'api.admin.oauth.mcp_token.revoke__confirm_title'|trans }}</h5>
+                                                                <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                            </div>
+                                                            <div class="modal-body text-start">
+                                                                <p class="text-start">{{ 'api.admin.oauth.mcp_token.revoke__confirm_message'|trans }}</p>
+                                                            </div>
+                                                            <div class="modal-footer">
+                                                                <button class="btn btn-ec-sub" type="button" data-bs-dismiss="modal">{{ 'admin.common.cancel'|trans }}</button>
+                                                                <a class="btn btn-ec-delete" href="{{ url('admin_api_mcp_token_revoke', {id: mcpToken.id}) }}"
+                                                                    {{ csrf_token_for_anchor() }} data-method="delete" data-confirm="false">
+                                                                    {{ 'api.admin.oauth.mcp_token.revoke'|trans }}
+                                                                </a>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
                 <div class="card rounded border-0 mb-4">
                     <a class="btn btn-ec-conversion ladda-button" href="{{ url('admin_api_oauth_clear_expired_tokens') }}"
                         {{ csrf_token_for_anchor() }} data-method="delete" data-confirm="false">

--- a/Resource/template/admin/OAuth/mcp_token.twig
+++ b/Resource/template/admin/OAuth/mcp_token.twig
@@ -1,0 +1,123 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+{% extends '@admin/default_frame.twig' %}
+
+{% set menus = ['setting', 'api', 'oauth'] %}
+
+{% block title %}{{ 'api.admin.oauth.mcp_token.registration'|trans }}{% endblock %}
+{% block sub_title %}{{ 'api.admin.management'|trans }}{% endblock %}
+
+{% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
+
+{% block main %}
+    <form name="mcp_token_form" role="form" id="mcp_token_form" method="post" action="" novalidate>
+        {{ form_widget(form._token) }}
+        <div class="c-contentsArea__cols">
+            <div class="c-contentsArea__primaryCol">
+                <div class="c-primaryCol">
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <div class="row">
+                                <div class="col-8">
+                                    <span class="card-title">{{ 'api.admin.oauth.mcp_token.registration'|trans }}</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="collapse show ec-cardCollapse" id="mcpTokenInfo">
+                            <div class="card-body">
+
+                                {# label #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.mcp_token.label_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.mcp_token.label'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ms-1"></i>
+                                            <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.label) }}
+                                            </div>
+                                            {{ form_errors(form.label) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# scope #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.mcp_token.scope_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.mcp_token.scope'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ms-1"></i>
+                                            <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.scopes, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                                            </div>
+                                            {{ form_errors(form.scopes) }}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {# expire #}
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.mcp_token.expire_tooltip'|trans }}">
+                                            <span>{{ 'api.admin.oauth.mcp_token.expire'|trans }}</span>
+                                            <i class="fa fa-question-circle fa-lg ms-1"></i>
+                                            <span class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span>
+                                        </label>
+                                    </div>
+                                    <div class="col">
+                                        <div class="row">
+                                            <div class="col">
+                                                {{ form_widget(form.expire) }}
+                                            </div>
+                                            {{ form_errors(form.expire) }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="c-conversionArea">
+            <div class="c-conversionArea__container">
+                <div class="row justify-content-between align-items-center">
+                    <div class="col-6">
+                        <div class="c-conversionArea__leftBlockItem">
+                            <a class="c-baseLink" href="{{ url('admin_api_oauth') }}">
+                                <i class="fa fa-backward" aria-hidden="true"></i>
+                                <span>{{ 'api.admin.oauth.management'|trans }}</span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <div id="ex-conversion-action" class="row align-items-center justify-content-end">
+                            <div class="col-auto">
+                                <button class="btn btn-ec-conversion px-5" type="submit">
+                                    {{ 'api.admin.oauth.mcp_token.issue'|trans }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/Resource/template/admin/OAuth/mcp_token_issued.twig
+++ b/Resource/template/admin/OAuth/mcp_token_issued.twig
@@ -1,0 +1,69 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+{% extends '@admin/default_frame.twig' %}
+
+{% set menus = ['setting', 'api', 'oauth'] %}
+
+{% block title %}{{ 'api.admin.oauth.mcp_token.issued_title'|trans }}{% endblock %}
+{% block sub_title %}{{ 'api.admin.management'|trans }}{% endblock %}
+
+{% block main %}
+    <div class="c-contentsArea__cols">
+        <div class="c-contentsArea__primaryCol">
+            <div class="c-primaryCol">
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-header">
+                        <span class="card-title">{{ 'api.admin.oauth.mcp_token.issued_title'|trans }}{% if label %} ({{ label }}){% endif %}</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="alert alert-warning" role="alert">
+                            {{ 'api.admin.oauth.mcp_token.issued_warning'|trans }}
+                        </div>
+                        <div class="row">
+                            <div class="col">
+                                <textarea id="mcp_token_value" class="form-control" rows="5" readonly>{{ token }}</textarea>
+                            </div>
+                            <div class="col-auto">
+                                <button type="button" class="btn btn-ec-regular" id="mcp_token_copy">
+                                    {{ 'api.admin.oauth.copy'|trans }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="c-conversionArea">
+        <div class="c-conversionArea__container">
+            <div class="row justify-content-between align-items-center">
+                <div class="col-6">
+                    <div class="c-conversionArea__leftBlockItem">
+                        <a class="c-baseLink" href="{{ url('admin_api_oauth') }}">
+                            <i class="fa fa-backward" aria-hidden="true"></i>
+                            <span>{{ 'api.admin.oauth.management'|trans }}</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        document.getElementById('mcp_token_copy').addEventListener('click', function () {
+            const textarea = document.getElementById('mcp_token_value');
+            textarea.select();
+            navigator.clipboard.writeText(textarea.value);
+        });
+    </script>
+{% endblock %}

--- a/Security/McpAuthenticationEntryPoint.php
+++ b/Security/McpAuthenticationEntryPoint.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Security;
+
+use Plugin\Api44\Service\OAuthMetadataBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+/**
+ * `^/<admin>/mcp` firewall の認証エントリポイント。
+ *
+ * league の OAuth2Authenticator は 401 に plain `WWW-Authenticate: Bearer` しか付けないため、
+ * RFC 9728 の `resource_metadata=` ポインタを足してクライアントが認可方法を自動発見できるようにする。
+ */
+class McpAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    public function __construct(
+        private readonly OAuthMetadataBuilder $metadataBuilder,
+    ) {
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        return new Response(
+            $authException?->getMessage() ?? 'Authentication required',
+            Response::HTTP_UNAUTHORIZED,
+            ['WWW-Authenticate' => $this->metadataBuilder->wwwAuthenticate()],
+        );
+    }
+}

--- a/Service/DcrCleanupResult.php
+++ b/Service/DcrCleanupResult.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Service;
+
+/**
+ * DCR 死蔵クライアント掃除の結果。
+ */
+final readonly class DcrCleanupResult
+{
+    /**
+     * @param list<string> $deletedClientIdentifiers 削除した (dry-run では削除対象の) client 識別子
+     * @param int          $keptActiveCount          有効トークンを持つため残した件数
+     * @param int          $examinedCount            grace を過ぎて検査した総件数
+     * @param bool         $dryRun                   true なら実削除せず対象を集計しただけ
+     */
+    public function __construct(
+        public array $deletedClientIdentifiers,
+        public int $keptActiveCount,
+        public int $examinedCount,
+        public bool $dryRun,
+    ) {
+    }
+
+    public function deletedCount(): int
+    {
+        return \count($this->deletedClientIdentifiers);
+    }
+}

--- a/Service/DcrClientCleaner.php
+++ b/Service/DcrClientCleaner.php
@@ -90,7 +90,7 @@ class DcrClientCleaner
 
         $client = $this->clientManager->find($identifier);
         if (null !== $client) {
-            // access token は client FK の ON DELETE CASCADE で消える
+            // client 削除で access は DB の ON DELETE CASCADE で消える (上の refresh 削除は access がまだ在る間に実行済み)
             $this->entityManager->remove($client);
         } else {
             // 追跡レコードはあるが league client が無い = 別経路削除 or 過去の部分失敗の残骸。 兆候として記録する

--- a/Service/DcrClientCleaner.php
+++ b/Service/DcrClientCleaner.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Service;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\AccessToken;
+use League\Bundle\OAuth2ServerBundle\Model\RefreshToken;
+use Plugin\Api44\Entity\DcrClient;
+use Plugin\Api44\Repository\DcrClientRepository;
+use Psr\Log\LoggerInterface;
+
+/**
+ * 動的クライアント登録 (DCR) で量産される死蔵クライアントを掃除する。
+ *
+ * 掃除対象 = 登録から grace 日数を過ぎ、 かつ有効な (失効/期限切れでない) access / refresh
+ * トークンを 1 つも持たない DCR クライアント。 再接続時は DCR でまた登録されるため削除して問題ない。
+ * in-flight (登録直後で同意未完了) の client を消さないよう grace で守る。
+ *
+ * トークンの FK: oauth2_access_token.client は ON DELETE CASCADE (client 削除で access も消える)。
+ * 一方 refresh は client への直接 FK が無く access_token への FK が ON DELETE SET NULL のため、
+ * client を消すだけでは孤立 refresh 行が残る。 削除時に refresh を明示削除して残骸を残さない。
+ *
+ * 掃除対象は追跡レコード (plg_api_dcr_client) のある client のみ。 機能導入前に作られた client や
+ * 登録時の記録に失敗した client は対象外 (作成時刻が無く grace 判定できないため)。
+ */
+class DcrClientCleaner
+{
+    public function __construct(
+        private readonly DcrClientRepository $dcrClientRepository,
+        private readonly ClientManagerInterface $clientManager,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function cleanup(\DateTimeInterface $now, int $graceDays, bool $dryRun): DcrCleanupResult
+    {
+        $threshold = \DateTimeImmutable::createFromInterface($now)
+            ->sub(new \DateInterval(sprintf('P%dD', $graceDays)));
+
+        $candidates = $this->dcrClientRepository->findRegisteredBefore($threshold);
+
+        // 副作用なしで分類する (有効トークンを持つものは残す)
+        $dead = [];
+        $keptActive = 0;
+        foreach ($candidates as $record) {
+            if ($this->hasLiveToken($record->getClientIdentifier(), $now)) {
+                ++$keptActive;
+                continue;
+            }
+            $dead[] = $record;
+        }
+        $deletedIdentifiers = array_map(static fn (DcrClient $r): string => $r->getClientIdentifier(), $dead);
+
+        // 削除は 1 トランザクションにまとめ、 途中失敗で「client だけ消えて追跡レコードが残る」
+        // 不整合を防ぐ (全件成功 or 全件未変更)。 失敗時は例外を呼び出し側 (コマンド) へ伝える。
+        if (!$dryRun && [] !== $dead) {
+            $this->entityManager->wrapInTransaction(function () use ($dead): void {
+                foreach ($dead as $record) {
+                    $this->deleteDeadClient($record);
+                }
+            });
+        }
+
+        return new DcrCleanupResult($deletedIdentifiers, $keptActive, \count($candidates), $dryRun);
+    }
+
+    private function deleteDeadClient(DcrClient $record): void
+    {
+        $identifier = $record->getClientIdentifier();
+
+        // client 削除では access への SET NULL で孤立する refresh を、 access が残っているうちに先に消す
+        $this->entityManager->createQuery(
+            'DELETE FROM '.RefreshToken::class.' r WHERE IDENTITY(r.accessToken) IN'
+            .' (SELECT a.identifier FROM '.AccessToken::class.' a WHERE IDENTITY(a.client) = :client)'
+        )->setParameter('client', $identifier)->execute();
+
+        $client = $this->clientManager->find($identifier);
+        if (null !== $client) {
+            // access token は client FK の ON DELETE CASCADE で消える
+            $this->entityManager->remove($client);
+        } else {
+            // 追跡レコードはあるが league client が無い = 別経路削除 or 過去の部分失敗の残骸。 兆候として記録する
+            $this->logger->notice('DCR cleanup: tracking record points to a missing OAuth client; removing orphan record', ['client_id' => $identifier]);
+        }
+        $this->entityManager->remove($record);
+    }
+
+    /**
+     * クライアントが現在も利用可能か (有効な access または refresh トークンを持つか) を判定する。
+     */
+    private function hasLiveToken(string $clientIdentifier, \DateTimeInterface $now): bool
+    {
+        // token の expiry は datetime_immutable (naive local 保存)。 :now を型指定せず束縛すると
+        // tz 変換で比較がズレるため、 同じ型で束縛して naive local 同士で比較する。
+        $nowParam = \DateTimeImmutable::createFromInterface($now);
+
+        $accessCount = (int) $this->entityManager->createQuery(
+            'SELECT COUNT(a.identifier) FROM '.AccessToken::class.' a'
+            .' WHERE IDENTITY(a.client) = :client AND a.revoked = false AND a.expiry > :now'
+        )
+            ->setParameter('client', $clientIdentifier)
+            ->setParameter('now', $nowParam, Types::DATETIME_IMMUTABLE)
+            ->getSingleScalarResult();
+        if ($accessCount > 0) {
+            return true;
+        }
+
+        $refreshCount = (int) $this->entityManager->createQuery(
+            'SELECT COUNT(r.identifier) FROM '.RefreshToken::class.' r JOIN r.accessToken a'
+            .' WHERE IDENTITY(a.client) = :client AND r.revoked = false AND r.expiry > :now'
+        )
+            ->setParameter('client', $clientIdentifier)
+            ->setParameter('now', $nowParam, Types::DATETIME_IMMUTABLE)
+            ->getSingleScalarResult();
+
+        return $refreshCount > 0;
+    }
+}

--- a/Service/McpTokenService.php
+++ b/Service/McpTokenService.php
@@ -120,10 +120,15 @@ class McpTokenService
         $mcpToken->setExpireDate(\DateTime::createFromInterface($expiry));
         $mcpToken->setCreateDate(new \DateTime());
 
+        // 失効判定の正本 (AccessToken model) にも JWT (108-112) と同じ scope を積む。 空にすると
+        // oauth2_access_token.scopes が JWT と恒久的に食い違い、 introspection・監査・scope ベースの
+        // 掃除など DB レコードを信頼する経路が誤動作する。
+        $modelScopes = array_map(static fn (string $scope): Scope => new Scope($scope), $scopes);
+
         // 失効判定の正本 (AccessToken model) と表示用メタを 1 トランザクションで永続化する。
         // どちらか一方だけ残ると「失効できない生トークン」や「実体のないメタ」が生じるため不可分にする。
-        $this->entityManager->wrapInTransaction(function () use ($identifier, $expiry, $client, $userIdentifier, $mcpToken): void {
-            $this->accessTokenManager->save(new AccessTokenModel($identifier, $expiry, $client, $userIdentifier, []));
+        $this->entityManager->wrapInTransaction(function () use ($identifier, $expiry, $client, $userIdentifier, $modelScopes, $mcpToken): void {
+            $this->accessTokenManager->save(new AccessTokenModel($identifier, $expiry, $client, $userIdentifier, $modelScopes));
             $this->entityManager->persist($mcpToken);
             $this->entityManager->flush();
         });

--- a/Service/McpTokenService.php
+++ b/Service/McpTokenService.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Entity\Member;
+use League\Bundle\OAuth2ServerBundle\Entity\AccessToken as AccessTokenEntity;
+use League\Bundle\OAuth2ServerBundle\Entity\Client as ClientEntity;
+use League\Bundle\OAuth2ServerBundle\Entity\Scope as ScopeEntity;
+use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\AccessToken as AccessTokenModel;
+use League\OAuth2\Server\CryptKey;
+use Plugin\Api44\Entity\McpToken;
+
+/**
+ * 管理画面から MCP 用のアクセストークン (PAT) を発行・失効する。
+ *
+ * 認証・失効の正本は league の AccessToken (oauth2_access_token)。 本サービスは
+ * 専用クライアント (CLIENT_IDENTIFIER) を使い、 操作中の Member に紐づく署名済み JWT を
+ * 発行する。 JWT 本体は保存せず発行時のみ返す。 表示用メタは McpToken に保存する。
+ */
+class McpTokenService
+{
+    /**
+     * PAT 専用の内部クライアント識別子 (PluginManager::enable で生成)。
+     */
+    public const CLIENT_IDENTIFIER = 'mcp_pat';
+
+    /**
+     * 発行を許可する scope。 MCP の領域別 read のみ (write/管理系は発行不可)。
+     *
+     * @var list<string>
+     */
+    public const AVAILABLE_SCOPES = [
+        'mcp:product:read',
+        'mcp:order:read',
+        'mcp:customer:read',
+        'mcp:plugin:read',
+    ];
+
+    /**
+     * 発行を許可する有効日数。 フォームのプリセットと一致させ、 フォーム外からの発行も縛る。
+     *
+     * @var list<int>
+     */
+    public const AVAILABLE_EXPIRE_DAYS = [30, 90, 180, 365];
+
+    public function __construct(
+        private readonly ClientManagerInterface $clientManager,
+        private readonly AccessTokenManagerInterface $accessTokenManager,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly string $privateKeyPath,
+    ) {
+    }
+
+    /**
+     * トークンを発行し、 署名済み JWT を返す (発行時のみ取得可能)。
+     *
+     * @param list<string> $scopes 要求 scope (mcp:*:read のみ採用)
+     * @param int          $expireDays 有効日数 (AVAILABLE_EXPIRE_DAYS のみ)
+     */
+    public function issue(Member $member, string $label, array $scopes, int $expireDays): string
+    {
+        // 防御的に mcp:*:read 以外を除外する (フォームの制限が外れても write 等を発行させない)
+        $scopes = array_values(array_intersect($scopes, self::AVAILABLE_SCOPES));
+        if ([] === $scopes) {
+            throw new \InvalidArgumentException('At least one MCP scope is required.');
+        }
+        // 有効日数も scope と同じくフォーム外からの値を縛る (0=即失効 や 過大な値を防ぐ)
+        if (!\in_array($expireDays, self::AVAILABLE_EXPIRE_DAYS, true)) {
+            throw new \InvalidArgumentException('Invalid expiration days.');
+        }
+        // 発行者 (sub / 監査) は必須。 null を 0 に丸めて誤った帰属を残さない
+        $memberId = $member->getId();
+        if (null === $memberId) {
+            throw new \InvalidArgumentException('Member id is required.');
+        }
+
+        $client = $this->clientManager->find(self::CLIENT_IDENTIFIER);
+        if (null === $client) {
+            throw new \RuntimeException(sprintf('OAuth2 client "%s" が存在しません。 Api44 を有効化してください。', self::CLIENT_IDENTIFIER));
+        }
+
+        $identifier = 'mcp-'.bin2hex(random_bytes(16));
+        $expiry = new \DateTimeImmutable(sprintf('+%d days', $expireDays));
+        $userIdentifier = $member->getUsername(); // login_id を JWT の sub にする
+
+        // JWT エンティティを組み立てる (副作用なし。 署名は永続化成功後に行う)
+        $tokenEntity = new AccessTokenEntity();
+        $tokenEntity->setIdentifier($identifier);
+        $tokenEntity->setExpiryDateTime($expiry);
+        $tokenEntity->setUserIdentifier($userIdentifier);
+        $clientEntity = new ClientEntity();
+        $clientEntity->setIdentifier(self::CLIENT_IDENTIFIER);
+        $tokenEntity->setClient($clientEntity);
+        foreach ($scopes as $scope) {
+            $scopeEntity = new ScopeEntity();
+            $scopeEntity->setIdentifier($scope);
+            $tokenEntity->addScope($scopeEntity);
+        }
+
+        // 表示用メタ (ラベル・scope・発行者・期限)
+        $mcpToken = new McpToken();
+        $mcpToken->setTokenIdentifier($identifier);
+        $mcpToken->setLabel($label);
+        $mcpToken->setScopes($scopes);
+        $mcpToken->setMemberId($memberId);
+        $mcpToken->setExpireDate(\DateTime::createFromInterface($expiry));
+        $mcpToken->setCreateDate(new \DateTime());
+
+        // 失効判定の正本 (AccessToken model) と表示用メタを 1 トランザクションで永続化する。
+        // どちらか一方だけ残ると「失効できない生トークン」や「実体のないメタ」が生じるため不可分にする。
+        $this->entityManager->wrapInTransaction(function () use ($identifier, $expiry, $client, $userIdentifier, $mcpToken): void {
+            $this->accessTokenManager->save(new AccessTokenModel($identifier, $expiry, $client, $userIdentifier, []));
+            $this->entityManager->persist($mcpToken);
+            $this->entityManager->flush();
+        });
+
+        // 永続化が確定してから署名する。 上で失敗した場合は JWT が一切生成されない (生トークンを残さない)
+        $tokenEntity->setPrivateKey(new CryptKey($this->privateKeyPath, null, false));
+
+        return $tokenEntity->toString();
+    }
+
+    /**
+     * トークンを失効する。 league token を revoke し (即 401)、 表示用メタを削除する。
+     *
+     * @return bool 失効対象の league token が見つかり失効できたか。 false の場合は
+     *              既に期限切れ削除済み等で revoke 対象が無かったことを示す (呼び出し側で警告する)
+     */
+    public function revoke(McpToken $mcpToken): bool
+    {
+        $accessToken = $this->accessTokenManager->find($mcpToken->getTokenIdentifier());
+        $found = null !== $accessToken;
+        if ($found) {
+            $accessToken->revoke();
+            $this->accessTokenManager->save($accessToken);
+        }
+
+        $this->entityManager->remove($mcpToken);
+        $this->entityManager->flush();
+
+        return $found;
+    }
+}

--- a/Service/McpTokenService.php
+++ b/Service/McpTokenService.php
@@ -21,6 +21,9 @@ use League\Bundle\OAuth2ServerBundle\Entity\Scope as ScopeEntity;
 use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\AccessToken as AccessTokenModel;
+use League\Bundle\OAuth2ServerBundle\Model\Client as ClientModel;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
 use League\OAuth2\Server\CryptKey;
 use Plugin\Api44\Entity\McpToken;
 
@@ -88,10 +91,7 @@ class McpTokenService
             throw new \InvalidArgumentException('Member id is required.');
         }
 
-        $client = $this->clientManager->find(self::CLIENT_IDENTIFIER);
-        if (null === $client) {
-            throw new \RuntimeException(sprintf('OAuth2 client "%s" が存在しません。 Api44 を有効化してください。', self::CLIENT_IDENTIFIER));
-        }
+        $client = $this->findOrCreatePatClient();
 
         $identifier = 'mcp-'.bin2hex(random_bytes(16));
         $expiry = new \DateTimeImmutable(sprintf('+%d days', $expireDays));
@@ -132,6 +132,32 @@ class McpTokenService
         $tokenEntity->setPrivateKey(new CryptKey($this->privateKeyPath, null, false));
 
         return $tokenEntity->toString();
+    }
+
+    /**
+     * PAT 発行用の内部クライアントを取得する。 無ければ冪等生成する。
+     *
+     * league の doctrine persistence は eccube:plugin:enable の時点では未配線のため、
+     * enable 時には生成できない。 実行時 (初回発行時) に生成する。 grant は
+     * authorization_code、 scope は MCP の領域別 read に固定する。
+     */
+    private function findOrCreatePatClient(): ClientModel
+    {
+        $client = $this->clientManager->find(self::CLIENT_IDENTIFIER);
+        if ($client instanceof ClientModel) {
+            return $client;
+        }
+
+        $client = new ClientModel('MCP PAT', self::CLIENT_IDENTIFIER, null);
+        $client->setActive(true);
+        $client->setGrants(new Grant('authorization_code'));
+        $client->setScopes(...array_map(
+            static fn (string $scope): Scope => new Scope($scope),
+            self::AVAILABLE_SCOPES,
+        ));
+        $this->clientManager->save($client);
+
+        return $client;
     }
 
     /**

--- a/Service/McpTokenService.php
+++ b/Service/McpTokenService.php
@@ -55,10 +55,12 @@ class McpTokenService
 
     /**
      * 発行を許可する有効日数。 フォームのプリセットと一致させ、 フォーム外からの発行も縛る。
+     * JWT の aud は resource URI に縛られない (OAuthMetadataBuilder 参照) ため、 トークンが有効な間は
+     * その scope で PII を読める。 露出期間を抑えるため上限を 180 日に留める。
      *
      * @var list<int>
      */
-    public const AVAILABLE_EXPIRE_DAYS = [30, 90, 180, 365];
+    public const AVAILABLE_EXPIRE_DAYS = [30, 90, 180];
 
     public function __construct(
         private readonly ClientManagerInterface $clientManager,

--- a/Service/OAuthMetadataBuilder.php
+++ b/Service/OAuthMetadataBuilder.php
@@ -13,6 +13,8 @@
 
 namespace Plugin\Api44\Service;
 
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -29,9 +31,16 @@ class OAuthMetadataBuilder
      */
     public const SCOPES = McpTokenService::AVAILABLE_SCOPES;
 
+    /**
+     * 本番で trusted hosts 未設定を検知したら 1 度だけ警告する (リクエスト内で baseUrl は多数回呼ばれるため)。
+     */
+    private bool $trustedHostWarned = false;
+
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly string $adminRoute,
+        private readonly LoggerInterface $logger,
+        private readonly string $kernelEnvironment,
     ) {
     }
 
@@ -46,8 +55,27 @@ class OAuthMetadataBuilder
         if (null === $request) {
             return '';
         }
+        $this->warnIfHostUntrusted();
 
         return $request->getSchemeAndHttpHost().$request->getBaseUrl();
+    }
+
+    /**
+     * trusted hosts 未設定のまま Host 由来の metadata を出すと、 Host ヘッダ偽装で resource_metadata に
+     * 偽ドメインを載せられ、 クライアントを攻撃者の認可サーバへ誘導され得る。 README で TRUSTED_HOSTS を
+     * 必須化しているが、 散文の約束は静かにドリフトするため、 本番での未設定を警告ログで顕在化させる
+     * (dev/test は空が正常なので prod に限定する)。
+     */
+    private function warnIfHostUntrusted(): void
+    {
+        if ($this->trustedHostWarned || 'prod' !== $this->kernelEnvironment) {
+            return;
+        }
+        $this->trustedHostWarned = true;
+
+        if ([] === Request::getTrustedHosts()) {
+            $this->logger->warning('MCP: TRUSTED_HOSTS が未設定です。 Host ヘッダ偽装で OAuth ディスカバリの resource_metadata に偽ドメインが載る恐れがあります。 本番では TRUSTED_HOSTS / TRUSTED_PROXIES を設定してください。');
+        }
     }
 
     /**

--- a/Service/OAuthMetadataBuilder.php
+++ b/Service/OAuthMetadataBuilder.php
@@ -18,7 +18,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * MCP の OAuth ディスカバリ用メタデータ (RFC 9728 / RFC 8414) と
  * 401 の WWW-Authenticate 値を一元生成する。 URL 組み立てを 1 箇所に集約し、
- * canonical resource URI を 3 者 (PRM の resource / WWW-Authenticate / token の aud クレーム) で一致させる。
+ * canonical resource URI を PRM の resource と WWW-Authenticate の 2 者で一致させる。
+ * JWT の aud はここでは扱わない。 league の AccessTokenTrait が client 識別子を入れるため、
+ * resource URI にはならない (resource へ寄せるには RFC 8707 相当の実装が別途必要)。
  */
 class OAuthMetadataBuilder
 {
@@ -34,7 +36,9 @@ class OAuthMetadataBuilder
     }
 
     /**
-     * 現在のリクエストから `<scheme>://<host>` を得る (リバースプロキシ対応は trusted proxies 設定に従う)。
+     * 現在のリクエストから `<scheme>://<host><base-path>` を得る (リバースプロキシ対応は trusted proxies 設定に従う)。
+     * base path を含めるのは、 サブディレクトリ配下 (例 /shop) に公開したとき resource / 各 endpoint の
+     * URL が base path 落ちで壊れるのを防ぐため。
      */
     public function baseUrl(): string
     {
@@ -43,7 +47,7 @@ class OAuthMetadataBuilder
             return '';
         }
 
-        return $request->getSchemeAndHttpHost();
+        return $request->getSchemeAndHttpHost().$request->getBaseUrl();
     }
 
     /**

--- a/Service/OAuthMetadataBuilder.php
+++ b/Service/OAuthMetadataBuilder.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * MCP の OAuth ディスカバリ用メタデータ (RFC 9728 / RFC 8414) と
  * 401 の WWW-Authenticate 値を一元生成する。 URL 組み立てを 1 箇所に集約し、
- * canonical resource URI を 3 者 (PRM の resource / WWW-Authenticate / Phase2 の aud) で一致させる。
+ * canonical resource URI を 3 者 (PRM の resource / WWW-Authenticate / token の aud クレーム) で一致させる。
  */
 class OAuthMetadataBuilder
 {

--- a/Service/OAuthMetadataBuilder.php
+++ b/Service/OAuthMetadataBuilder.php
@@ -108,8 +108,8 @@ class OAuthMetadataBuilder
             'token_endpoint_auth_methods_supported' => ['none'],
             'code_challenge_methods_supported' => ['S256'],
             'scopes_supported' => self::SCOPES,
-            // iss は Phase 2 (RFC 9207) で導入予定。 現状は未対応を明示し、 クライアントの検証と齟齬を出さない
-            'authorization_response_iss_parameter_supported' => false,
+            // RFC 9207 対応済み。 認可応答に issuer (=この issuer) を付与する (AuthorizationResponseIssListener)
+            'authorization_response_iss_parameter_supported' => true,
         ];
     }
 }

--- a/Service/OAuthMetadataBuilder.php
+++ b/Service/OAuthMetadataBuilder.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Service;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * MCP の OAuth ディスカバリ用メタデータ (RFC 9728 / RFC 8414) と
+ * 401 の WWW-Authenticate 値を一元生成する。 URL 組み立てを 1 箇所に集約し、
+ * canonical resource URI を 3 者 (PRM の resource / WWW-Authenticate / Phase2 の aud) で一致させる。
+ */
+class OAuthMetadataBuilder
+{
+    /**
+     * @var list<string> 配信する scope (ワイルドカードでなく具体値)。 全箇所で同一集合を使う
+     */
+    public const SCOPES = McpTokenService::AVAILABLE_SCOPES;
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly string $adminRoute,
+    ) {
+    }
+
+    /**
+     * 現在のリクエストから `<scheme>://<host>` を得る (リバースプロキシ対応は trusted proxies 設定に従う)。
+     */
+    public function baseUrl(): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return '';
+        }
+
+        return $request->getSchemeAndHttpHost();
+    }
+
+    /**
+     * MCP サーバの canonical URI (trailing-slash なし)。 PRM の resource と一致させる。
+     */
+    public function resourceUri(): string
+    {
+        return $this->baseUrl().'/'.$this->adminRoute.'/mcp';
+    }
+
+    /**
+     * Protected Resource Metadata の絶対 URL (host ルート形)。
+     */
+    public function protectedResourceMetadataUrl(): string
+    {
+        return $this->baseUrl().'/.well-known/oauth-protected-resource';
+    }
+
+    /**
+     * 401 の WWW-Authenticate ヘッダ値 (RFC 6750 + RFC 9728)。
+     */
+    public function wwwAuthenticate(): string
+    {
+        return sprintf(
+            'Bearer resource_metadata="%s", scope="%s"',
+            $this->protectedResourceMetadataUrl(),
+            implode(' ', self::SCOPES),
+        );
+    }
+
+    /**
+     * RFC 9728 Protected Resource Metadata.
+     *
+     * @return array<string, mixed>
+     */
+    public function protectedResourceMetadata(): array
+    {
+        return [
+            'resource' => $this->resourceUri(),
+            'authorization_servers' => [$this->baseUrl()],
+            'scopes_supported' => self::SCOPES,
+            'bearer_methods_supported' => ['header'],
+        ];
+    }
+
+    /**
+     * RFC 8414 Authorization Server Metadata.
+     *
+     * @return array<string, mixed>
+     */
+    public function authorizationServerMetadata(): array
+    {
+        $base = $this->baseUrl();
+
+        return [
+            'issuer' => $base,
+            'authorization_endpoint' => $base.'/'.$this->adminRoute.'/authorize',
+            'token_endpoint' => $base.'/token',
+            'registration_endpoint' => $base.'/register',
+            'response_types_supported' => ['code'],
+            'grant_types_supported' => ['authorization_code', 'refresh_token'],
+            'token_endpoint_auth_methods_supported' => ['none'],
+            'code_challenge_methods_supported' => ['S256'],
+            'scopes_supported' => self::SCOPES,
+            // iss は Phase 2 (RFC 9207) で導入予定。 現状は未対応を明示し、 クライアントの検証と齟齬を出さない
+            'authorization_response_iss_parameter_supported' => false,
+        ];
+    }
+}

--- a/Tests/DependencyInjection/ApiExtensionTest.php
+++ b/Tests/DependencyInjection/ApiExtensionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\Api44\DependencyInjection\ApiExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * `ApiExtension::prepend()` の firewall 注入仕様を検証する。
+ *
+ * - `api` / `mcp` firewall が `admin` の **前**に挿入される (順序が重要: パスマッチで先勝ち)
+ * - `mcp` firewall は MCP サーバ (本体同梱) 用で `^/<admin_route>/mcp` を OAuth2 stateless で処理
+ * - 既存の admin / customer firewall の `csrf_token_generator` と `anonymous` が削除される
+ */
+final class ApiExtensionTest extends TestCase
+{
+    public function testPrependInsertsApiAndMcpFirewallsBeforeAdmin(): void
+    {
+        $container = $this->makeContainerWithSecurityConfig();
+
+        (new ApiExtension())->prepend($container);
+
+        $firewalls = $this->extractFirewalls($container);
+        $names = array_keys($firewalls);
+
+        // 順序保証: dev → api → mcp → admin → customer
+        // (mcp は admin の前にないと `^/<admin>/mcp` のリクエストが admin firewall に拾われてしまう)
+        $this->assertSame(['dev', 'api', 'mcp', 'admin', 'customer'], $names);
+    }
+
+    public function testMcpFirewallShapeMatchesDesign(): void
+    {
+        $container = $this->makeContainerWithSecurityConfig();
+        (new ApiExtension())->prepend($container);
+
+        $mcp = $this->extractFirewalls($container)['mcp'];
+
+        $this->assertSame('^/%eccube_admin_route%/mcp', $mcp['pattern']);
+        $this->assertTrue($mcp['security']);
+        $this->assertTrue($mcp['stateless']);
+        $this->assertTrue($mcp['oauth2']);
+        $this->assertSame('member_provider', $mcp['provider']);
+    }
+
+    public function testAdminFirewallLosesCsrfTokenAndAnonymous(): void
+    {
+        $container = $this->makeContainerWithSecurityConfig();
+        (new ApiExtension())->prepend($container);
+
+        $admin = $this->extractFirewalls($container)['admin'];
+
+        $this->assertArrayNotHasKey('csrf_token_generator', $admin['form_login']);
+        $this->assertArrayNotHasKey('anonymous', $admin);
+        // 既存の他の form_login 設定は維持される
+        $this->assertSame('admin_login', $admin['form_login']['check_path']);
+    }
+
+    public function testCustomerFirewallLosesCsrfTokenAndAnonymous(): void
+    {
+        $container = $this->makeContainerWithSecurityConfig();
+        (new ApiExtension())->prepend($container);
+
+        $customer = $this->extractFirewalls($container)['customer'];
+
+        $this->assertArrayNotHasKey('csrf_token_generator', $customer['form_login']);
+        $this->assertArrayNotHasKey('anonymous', $customer);
+        $this->assertSame('mypage_login', $customer['form_login']['check_path']);
+    }
+
+    private function makeContainerWithSecurityConfig(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->prependExtensionConfig('security', [
+            'firewalls' => [
+                'dev' => ['pattern' => '^/(_(profiler|wdt))/', 'security' => false],
+                'admin' => [
+                    'pattern' => '^/%eccube_admin_route%/',
+                    'provider' => 'member_provider',
+                    'form_login' => [
+                        'check_path' => 'admin_login',
+                        'csrf_token_generator' => 'security.csrf.token_manager',
+                    ],
+                    'anonymous' => true,
+                ],
+                'customer' => [
+                    'pattern' => '^/',
+                    'provider' => 'customer_provider',
+                    'form_login' => [
+                        'check_path' => 'mypage_login',
+                        'csrf_token_generator' => 'security.csrf.token_manager',
+                    ],
+                    'anonymous' => true,
+                ],
+            ],
+        ]);
+
+        return $container;
+    }
+
+    /**
+     * `ContainerBuilder::$extensionConfigs` (private) を Reflection で読む。
+     * 同一 extension に prepend が複数回あった場合 [0] が最後に prepend された config。
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function extractFirewalls(ContainerBuilder $container): array
+    {
+        $refl = new \ReflectionProperty(ContainerBuilder::class, 'extensionConfigs');
+        $configs = $refl->getValue($container);
+        $this->assertArrayHasKey('security', $configs);
+
+        $firewalls = $configs['security'][0]['firewalls'];
+        $this->assertIsArray($firewalls);
+
+        return $firewalls;
+    }
+}

--- a/Tests/DependencyInjection/ApiExtensionTest.php
+++ b/Tests/DependencyInjection/ApiExtensionTest.php
@@ -37,9 +37,15 @@ final class ApiExtensionTest extends TestCase
         $firewalls = $this->extractFirewalls($container);
         $names = array_keys($firewalls);
 
-        // 順序保証: dev → api → mcp → admin → customer
-        // (mcp は admin の前にないと `^/<admin>/mcp` のリクエストが admin firewall に拾われてしまう)
-        $this->assertSame(['dev', 'api', 'mcp', 'admin', 'customer'], $names);
+        // 順序保証: dev → mcp_oauth_public → api → mcp → admin → customer
+        // (いずれも admin の前にないと `^/<admin>/mcp` や公開 well-known が admin firewall に拾われてしまう)
+        $this->assertSame(['dev', 'mcp_oauth_public', 'api', 'mcp', 'admin', 'customer'], $names);
+
+        // OAuth ディスカバリの公開エンドポイントは認証なし、 かつ実在 2 well-known と /register に
+        // **完全一致**で限定する (前方一致だと無関係パスを公開化してしまう)。
+        $public = $firewalls['mcp_oauth_public'];
+        $this->assertFalse($public['security']);
+        $this->assertSame('^/(\.well-known/oauth-(protected-resource|authorization-server)|register)$', $public['pattern']);
     }
 
     public function testMcpFirewallShapeMatchesDesign(): void
@@ -54,6 +60,8 @@ final class ApiExtensionTest extends TestCase
         $this->assertTrue($mcp['stateless']);
         $this->assertTrue($mcp['oauth2']);
         $this->assertSame('member_provider', $mcp['provider']);
+        // 401 は専用 entry_point で RFC 9728 の resource_metadata 付き WWW-Authenticate を返す
+        $this->assertSame('Plugin\Api44\Security\McpAuthenticationEntryPoint', $mcp['entry_point']);
     }
 
     public function testAdminFirewallLosesCsrfTokenAndAnonymous(): void

--- a/Tests/DependencyInjection/ApiExtensionTest.php
+++ b/Tests/DependencyInjection/ApiExtensionTest.php
@@ -89,6 +89,22 @@ final class ApiExtensionTest extends TestCase
         $this->assertSame('mypage_login', $customer['form_login']['check_path']);
     }
 
+    public function testPrependPinsRequireCodeChallengeForPublicClients(): void
+    {
+        $container = $this->makeContainerWithSecurityConfig();
+
+        (new ApiExtension())->prepend($container);
+
+        $refl = new \ReflectionProperty(ContainerBuilder::class, 'extensionConfigs');
+        $configs = $refl->getValue($container);
+
+        // PKCE(S256) 必須をライブラリ既定に依存せず明示的に pin する (将来の既定変更で静かに無効化させない)
+        $this->assertArrayHasKey('league_oauth2_server', $configs);
+        $this->assertTrue(
+            $configs['league_oauth2_server'][0]['authorization_server']['require_code_challenge_for_public_clients'],
+        );
+    }
+
     private function makeContainerWithSecurityConfig(): ContainerBuilder
     {
         $container = new ContainerBuilder();

--- a/Tests/EventListener/AuthorizationResponseIssListenerTest.php
+++ b/Tests/EventListener/AuthorizationResponseIssListenerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\Api44\EventListener\AuthorizationResponseIssListener;
+use Plugin\Api44\Service\OAuthMetadataBuilder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * RFC 9207 の iss 付与リスナーの単体テスト。
+ *
+ * 認可応答に AS の issuer が載ること、 および redirect_uri 由来の (= client 制御の) 既存 iss を
+ * AS の issuer で上書きすることを検証する。
+ */
+final class AuthorizationResponseIssListenerTest extends TestCase
+{
+    private function dispatch(string $location): string
+    {
+        $metadata = $this->createMock(OAuthMetadataBuilder::class);
+        $metadata->method('baseUrl')->willReturn('https://as.example');
+        $listener = new AuthorizationResponseIssListener($metadata);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'oauth2_authorize');
+        $response = new RedirectResponse($location);
+        $event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        $listener->onKernelResponse($event);
+
+        return (string) $response->headers->get('Location');
+    }
+
+    public function testAddsIssuerToSuccessResponse(): void
+    {
+        $location = $this->dispatch('https://client.example/cb?code=abc&state=xyz');
+
+        parse_str((string) parse_url($location, PHP_URL_QUERY), $params);
+        $this->assertSame('https://as.example', $params['iss']);
+        $this->assertSame('abc', $params['code']);
+        $this->assertSame('xyz', $params['state']);
+    }
+
+    public function testOverwritesClientControlledIss(): void
+    {
+        // redirect_uri に仕込まれた iss は client 制御なので、 AS の issuer で上書きされる
+        $location = $this->dispatch('https://client.example/cb?iss=https://evil.example&code=abc');
+
+        parse_str((string) parse_url($location, PHP_URL_QUERY), $params);
+        $this->assertSame('https://as.example', $params['iss']);
+        $this->assertSame('abc', $params['code']);
+    }
+
+    public function testIgnoresNonAuthorizationResponse(): void
+    {
+        // code / error を持たない redirect (ログイン画面等) には iss を付けない
+        $location = $this->dispatch('https://client.example/login');
+
+        $this->assertStringNotContainsString('iss=', $location);
+    }
+}

--- a/Tests/EventListener/AuthorizationResponseIssListenerTest.php
+++ b/Tests/EventListener/AuthorizationResponseIssListenerTest.php
@@ -77,4 +77,18 @@ final class AuthorizationResponseIssListenerTest extends TestCase
 
         $this->assertStringNotContainsString('iss=', $location);
     }
+
+    public function testPreservesQueryBearingRedirectUri(): void
+    {
+        // parse_str/http_build_query で丸ごと再構築すると、 名前の '.'→'_'・空白畳み・重複キー畳み・
+        // arr[]→arr[0] でクエリが壊れる。 client が登録した redirect_uri のクエリは原文のまま保ち、
+        // iss だけを末尾に足すことを検証する。
+        $rawQuery = 'a.b=1&x%20y=2&dup=1&dup=2&arr[]=9&code=CODE';
+        $location = $this->dispatch('https://client.example/cb?'.$rawQuery);
+
+        $this->assertSame(
+            $rawQuery.'&iss=https%3A%2F%2Fas.example',
+            (string) parse_url($location, PHP_URL_QUERY),
+        );
+    }
 }

--- a/Tests/Service/DcrClientCleanerTest.php
+++ b/Tests/Service/DcrClientCleanerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Tests\EccubeTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\AccessToken;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Entity\DcrClient;
+use Plugin\Api44\Repository\DcrClientRepository;
+use Plugin\Api44\Service\DcrClientCleaner;
+
+/**
+ * DCR 死蔵クライアント掃除の契約テスト。
+ *
+ * grace を過ぎ有効トークンを持たない DCR クライアントだけを削除し、 grace 内・有効トークン持ち・
+ * dry-run は消さないことを実挙動で担保する。
+ */
+class DcrClientCleanerTest extends EccubeTestCase
+{
+    private ?DcrClientCleaner $cleaner = null;
+    private ?DcrClientRepository $dcrClientRepository = null;
+    private ?ClientManagerInterface $clientManager = null;
+    private ?AccessTokenManagerInterface $accessTokenManager = null;
+    private ?EntityManagerInterface $em = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cleaner = static::getContainer()->get(DcrClientCleaner::class);
+        $this->dcrClientRepository = static::getContainer()->get(DcrClientRepository::class);
+        $this->clientManager = static::getContainer()->get(ClientManagerInterface::class);
+        $this->accessTokenManager = static::getContainer()->get(AccessTokenManagerInterface::class);
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testDeletesAbandonedClientPastGrace(): void
+    {
+        $id = $this->registerDcrClient('dcr-old-notoken', 40);
+
+        $result = $this->runCleanup(30, false);
+
+        $this->assertContains($id, $result->deletedClientIdentifiers);
+        $this->assertNull($this->clientManager->find($id), 'league client は削除される');
+        $this->assertNull($this->dcrClientRepository->findOneBy(['clientIdentifier' => $id]), '追跡レコードも削除される');
+    }
+
+    public function testKeepsClientWithinGrace(): void
+    {
+        $id = $this->registerDcrClient('dcr-recent', 5);
+
+        $result = $this->runCleanup(30, false);
+
+        $this->assertNotContains($id, $result->deletedClientIdentifiers);
+        $this->assertNotNull($this->clientManager->find($id), 'grace 内の client は残る');
+    }
+
+    public function testKeepsClientWithLiveAccessToken(): void
+    {
+        $id = $this->registerDcrClient('dcr-old-live', 40);
+        $this->issueAccessToken($id, new \DateTimeImmutable('+1 hour'), false);
+
+        $result = $this->runCleanup(30, false);
+
+        $this->assertNotContains($id, $result->deletedClientIdentifiers);
+        $this->assertSame(1, $result->keptActiveCount);
+        $this->assertNotNull($this->clientManager->find($id), '有効トークンを持つ client は残る');
+    }
+
+    public function testDeletesClientWithOnlyExpiredToken(): void
+    {
+        $id = $this->registerDcrClient('dcr-old-expired', 40);
+        $this->issueAccessToken($id, new \DateTimeImmutable('-1 hour'), false);
+
+        $result = $this->runCleanup(30, false);
+
+        $this->assertContains($id, $result->deletedClientIdentifiers);
+        $this->assertNull($this->clientManager->find($id), '期限切れトークンのみの client は削除される');
+    }
+
+    public function testDryRunReportsButDeletesNothing(): void
+    {
+        $id = $this->registerDcrClient('dcr-old-dryrun', 40);
+
+        $result = $this->runCleanup(30, true);
+
+        $this->assertTrue($result->dryRun);
+        $this->assertContains($id, $result->deletedClientIdentifiers, 'dry-run でも対象として報告する');
+        $this->assertNotNull($this->clientManager->find($id), 'dry-run では実削除しない');
+        $this->assertNotNull($this->dcrClientRepository->findOneBy(['clientIdentifier' => $id]), 'dry-run では追跡レコードも残す');
+    }
+
+    /**
+     * DCR クライアント (league Client + 追跡レコード) を作り、 登録時刻を $ageDays 日前にする。
+     */
+    private function registerDcrClient(string $identifier, int $ageDays): string
+    {
+        $client = new Client('DCR:test', $identifier, null);
+        $client->setActive(true);
+        $client->setGrants(new Grant('authorization_code'), new Grant('refresh_token'));
+        $client->setScopes(new Scope('mcp:product:read'));
+        $this->clientManager->save($client);
+
+        $record = new DcrClient();
+        $record->setClientIdentifier($identifier);
+        $record->setCreateDate(new \DateTime());
+        $this->em->persist($record);
+        $this->em->flush();
+
+        // EC-CUBE の timestampable が persist 時に create_date を now で上書きするため、
+        // 過去の登録時刻は lifecycle を迂回する DQL UPDATE で直接設定する。
+        $this->em->createQuery(
+            'UPDATE '.DcrClient::class.' d SET d.createDate = :date WHERE d.clientIdentifier = :id'
+        )
+            ->setParameter('date', (new \DateTime())->modify(sprintf('-%d days', $ageDays)))
+            ->setParameter('id', $identifier)
+            ->execute();
+
+        return $identifier;
+    }
+
+    private function issueAccessToken(string $clientIdentifier, \DateTimeInterface $expiry, bool $revoked): void
+    {
+        $client = $this->clientManager->find($clientIdentifier);
+        $token = new AccessToken('at-'.$clientIdentifier, $expiry, $client, 'admin', [new Scope('mcp:product:read')]);
+        if ($revoked) {
+            $token->revoke();
+        }
+        $this->accessTokenManager->save($token);
+        $this->em->flush();
+    }
+
+    /**
+     * 準備した DB 状態を確定し、 EM を空にしてから掃除を実行する
+     * (cleaner が identity map の残存ではなく DB の実状態を見るようにする)。
+     */
+    private function runCleanup(int $graceDays, bool $dryRun): \Plugin\Api44\Service\DcrCleanupResult
+    {
+        $this->em->flush();
+        $this->em->clear();
+
+        return $this->cleaner->cleanup(new \DateTime(), $graceDays, $dryRun);
+    }
+}

--- a/Tests/Service/OAuthMetadataBuilderTest.php
+++ b/Tests/Service/OAuthMetadataBuilderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Service;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\Api44\Service\OAuthMetadataBuilder;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * TRUSTED_HOSTS 未設定ガードの単体テスト。
+ *
+ * Host 由来の metadata を本番で trusted hosts 未設定のまま配信すると Host 偽装で偽ドメインを載せられるため、
+ * README の必須化 (散文の約束) に加え、 未設定を警告ログで顕在化させる。 その挙動を縛る。
+ */
+final class OAuthMetadataBuilderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // 静的な trusted hosts を既定 (空) に戻し、 後続テストへ漏らさない
+        Request::setTrustedHosts([]);
+        parent::tearDown();
+    }
+
+    public function testWarnsWhenTrustedHostsUnsetInProd(): void
+    {
+        Request::setTrustedHosts([]);
+        $logger = $this->createMock(LoggerInterface::class);
+        // 1 リクエストで baseUrl は多数回呼ばれるが警告は 1 度だけ
+        $logger->expects($this->once())->method('warning');
+
+        $builder = $this->buildFor('prod', $logger);
+        $builder->baseUrl();
+        $builder->baseUrl();
+    }
+
+    public function testDoesNotWarnInDev(): void
+    {
+        Request::setTrustedHosts([]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $this->buildFor('dev', $logger)->baseUrl();
+    }
+
+    public function testDoesNotWarnWhenTrustedHostsConfiguredInProd(): void
+    {
+        Request::setTrustedHosts(['^example\.com$']);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $this->buildFor('prod', $logger)->baseUrl();
+    }
+
+    private function buildFor(string $env, LoggerInterface $logger): OAuthMetadataBuilder
+    {
+        $stack = new RequestStack();
+        $stack->push(Request::create('https://example.com/'));
+
+        return new OAuthMetadataBuilder($stack, 'admin', $logger, $env);
+    }
+}

--- a/Tests/Web/Admin/McpTokenControllerAuthorityTest.php
+++ b/Tests/Web/Admin/McpTokenControllerAuthorityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Web\Admin;
+
+use Eccube\Entity\Master\Authority;
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use Plugin\Api44\Service\McpTokenService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MCP トークン発行の認可ゲート契約テスト。
+ *
+ * 制限管理者 (authority != ADMIN) は URL 認可で管理画面を塞がれても stateless な mcp firewall では
+ * 再評価されないため、 発行時に ADMIN を要求して第二の扉を塞ぐ (対話型同意フローと対称)。
+ */
+class McpTokenControllerAuthorityTest extends AbstractAdminWebTestCase
+{
+    public function testCreateForbiddenForNonAdminAuthority(): void
+    {
+        $member = $this->createMember();
+        $member->setAuthority($this->entityManager->find(Authority::class, Authority::OWNER));
+        $this->entityManager->flush();
+        $this->loginTo($member);
+
+        $url = $this->generateUrl('admin_api_mcp_token_new');
+        $crawler = $this->client->request(Request::METHOD_GET, $url);
+
+        $formData = [
+            'label' => 'restricted-admin',
+            'scopes' => [McpTokenService::AVAILABLE_SCOPES[0]],
+            'expire' => McpTokenService::AVAILABLE_EXPIRE_DAYS[0],
+        ];
+        // CSRF が有効な環境では発行画面の hidden token を使う (無効ならフィールド自体が無い)
+        $tokenNode = $crawler->filter('input[name="mcp_token[_token]"]');
+        if ($tokenNode->count() > 0) {
+            $formData['_token'] = $tokenNode->attr('value');
+        }
+
+        $this->client->request(Request::METHOD_POST, $url, ['mcp_token' => $formData]);
+
+        $this->assertSame(
+            Response::HTTP_FORBIDDEN,
+            $this->client->getResponse()->getStatusCode(),
+            '制限管理者 (authority != ADMIN) は MCP トークンを発行できない',
+        );
+    }
+}

--- a/Tests/Web/Admin/McpTokenControllerTest.php
+++ b/Tests/Web/Admin/McpTokenControllerTest.php
@@ -69,6 +69,15 @@ class McpTokenControllerTest extends EccubeTestCase
         $this->mcpTokenService->issue($this->member, 'bad-expire', ['mcp:product:read'], 9999);
     }
 
+    public function testIssueRejectsShortenedMaxExpireDays(): void
+    {
+        // 露出期間を抑えるため上限を 180 日に短縮した。 以前有効だった 365 日は発行不可 (境界の回帰ガード)
+        $this->assertSame(180, max(McpTokenService::AVAILABLE_EXPIRE_DAYS));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mcpTokenService->issue($this->member, 'year', ['mcp:product:read'], 365);
+    }
+
     public function testIssuePersistsScopesOnAccessTokenModel(): void
     {
         // 失効判定の正本 (AccessToken model) にも scope が積まれる。 JWT と DB が食い違うと

--- a/Tests/Web/Admin/McpTokenControllerTest.php
+++ b/Tests/Web/Admin/McpTokenControllerTest.php
@@ -20,17 +20,15 @@ use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope as ScopeValue;
-use Plugin\Api44\Entity\McpToken;
 use Plugin\Api44\Repository\McpTokenRepository;
 use Plugin\Api44\Service\McpTokenService;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
- * MCP トークン発行機能の契約テスト。
+ * MCP トークン発行サービスの契約テスト。
  *
- * 発行したトークンが `/admin/mcp` の firewall を通り、 失効すると即 401 になること、
- * 発行できる scope が MCP の read に限られることを担保する。
+ * 発行できる scope が MCP の read に限られ、 有効日数がプリセットに縛られることを担保する。
+ * 発行したトークンが `/admin/mcp` firewall を通る/失効で 401 になる統合は、 MCP サーバ
+ * (本体同梱) と Api44 が揃う本体の mcp ジョブ (McpTokenRevocationContractTest) で実走する。
  */
 class McpTokenControllerTest extends EccubeTestCase
 {
@@ -45,33 +43,6 @@ class McpTokenControllerTest extends EccubeTestCase
         $this->mcpTokenService = static::getContainer()->get(McpTokenService::class);
         $this->mcpTokenRepository = static::getContainer()->get(McpTokenRepository::class);
         $this->member = static::getContainer()->get(MemberRepository::class)->findOneBy([]);
-    }
-
-    public function testIssuedTokenIsAcceptedByMcpEndpoint(): void
-    {
-        $jwt = $this->mcpTokenService->issue($this->member, 'test token', ['mcp:product:read'], 30);
-
-        $this->mcpRequest($jwt);
-
-        $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
-    }
-
-    public function testRevokedTokenReturns401(): void
-    {
-        $jwt = $this->mcpTokenService->issue($this->member, 'revoke me', ['mcp:product:read'], 30);
-
-        // 発行直後は通る
-        $this->mcpRequest($jwt);
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-
-        // 失効すると同じトークンで 401
-        $mcpToken = $this->mcpTokenRepository->findOneBy([], ['id' => 'DESC']);
-        $this->assertInstanceOf(McpToken::class, $mcpToken);
-        $this->mcpTokenService->revoke($mcpToken);
-
-        $this->mcpRequest($jwt);
-        $this->assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
     }
 
     public function testIssueRejectsNonMcpScopesOnly(): void
@@ -95,24 +66,6 @@ class McpTokenControllerTest extends EccubeTestCase
         // プリセット外の有効日数 (フォームバイパス) は発行できない
         $this->expectException(\InvalidArgumentException::class);
         $this->mcpTokenService->issue($this->member, 'bad-expire', ['mcp:product:read'], 9999);
-    }
-
-    /**
-     * `/admin/mcp` に initialize を投げ、 firewall の通過可否を見る (handshake の成否)。
-     */
-    private function mcpRequest(string $bearerJwt): void
-    {
-        $adminRoute = static::getContainer()->getParameter('eccube_admin_route');
-        $this->client->request(
-            Request::METHOD_POST,
-            '/'.$adminRoute.'/mcp',
-            server: [
-                'CONTENT_TYPE' => 'application/json',
-                'HTTP_ACCEPT' => 'application/json, text/event-stream',
-                'HTTP_AUTHORIZATION' => 'Bearer '.$bearerJwt,
-            ],
-            content: '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"t","version":"1"},"capabilities":{}}}',
-        );
     }
 
     private function ensureMcpPatClient(): void

--- a/Tests/Web/Admin/McpTokenControllerTest.php
+++ b/Tests/Web/Admin/McpTokenControllerTest.php
@@ -16,6 +16,7 @@ namespace Plugin\Api44\Tests\Web\Admin;
 use Eccube\Entity\Member;
 use Eccube\Repository\MemberRepository;
 use Eccube\Tests\EccubeTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\AccessTokenManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
@@ -66,6 +67,21 @@ class McpTokenControllerTest extends EccubeTestCase
         // プリセット外の有効日数 (フォームバイパス) は発行できない
         $this->expectException(\InvalidArgumentException::class);
         $this->mcpTokenService->issue($this->member, 'bad-expire', ['mcp:product:read'], 9999);
+    }
+
+    public function testIssuePersistsScopesOnAccessTokenModel(): void
+    {
+        // 失効判定の正本 (AccessToken model) にも scope が積まれる。 JWT と DB が食い違うと
+        // introspection・監査・scope ベースの掃除が壊れるため、 model 側の scope を直接縛る。
+        $this->mcpTokenService->issue($this->member, 'model-scope', ['mcp:product:read', 'mcp:order:read'], 30);
+
+        $mcpToken = $this->mcpTokenRepository->findOneBy([], ['id' => 'DESC']);
+        $accessToken = static::getContainer()->get(AccessTokenManagerInterface::class)->find($mcpToken->getTokenIdentifier());
+        $this->assertNotNull($accessToken);
+
+        $scopes = array_map(static fn ($scope): string => (string) $scope, $accessToken->getScopes());
+        sort($scopes);
+        $this->assertSame(['mcp:order:read', 'mcp:product:read'], $scopes);
     }
 
     private function ensureMcpPatClient(): void

--- a/Tests/Web/Admin/McpTokenControllerTest.php
+++ b/Tests/Web/Admin/McpTokenControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Web\Admin;
+
+use Eccube\Entity\Member;
+use Eccube\Repository\MemberRepository;
+use Eccube\Tests\EccubeTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope as ScopeValue;
+use Plugin\Api44\Entity\McpToken;
+use Plugin\Api44\Repository\McpTokenRepository;
+use Plugin\Api44\Service\McpTokenService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MCP トークン発行機能の契約テスト。
+ *
+ * 発行したトークンが `/admin/mcp` の firewall を通り、 失効すると即 401 になること、
+ * 発行できる scope が MCP の read に限られることを担保する。
+ */
+class McpTokenControllerTest extends EccubeTestCase
+{
+    private ?McpTokenService $mcpTokenService = null;
+    private ?McpTokenRepository $mcpTokenRepository = null;
+    private ?Member $member = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensureMcpPatClient();
+        $this->mcpTokenService = static::getContainer()->get(McpTokenService::class);
+        $this->mcpTokenRepository = static::getContainer()->get(McpTokenRepository::class);
+        $this->member = static::getContainer()->get(MemberRepository::class)->findOneBy([]);
+    }
+
+    public function testIssuedTokenIsAcceptedByMcpEndpoint(): void
+    {
+        $jwt = $this->mcpTokenService->issue($this->member, 'test token', ['mcp:product:read'], 30);
+
+        $this->mcpRequest($jwt);
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+    }
+
+    public function testRevokedTokenReturns401(): void
+    {
+        $jwt = $this->mcpTokenService->issue($this->member, 'revoke me', ['mcp:product:read'], 30);
+
+        // 発行直後は通る
+        $this->mcpRequest($jwt);
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        // 失効すると同じトークンで 401
+        $mcpToken = $this->mcpTokenRepository->findOneBy([], ['id' => 'DESC']);
+        $this->assertInstanceOf(McpToken::class, $mcpToken);
+        $this->mcpTokenService->revoke($mcpToken);
+
+        $this->mcpRequest($jwt);
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testIssueRejectsNonMcpScopesOnly(): void
+    {
+        // mcp:*:read 以外だけを要求した場合は発行できない
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mcpTokenService->issue($this->member, 'bad', ['read', 'write'], 30);
+    }
+
+    public function testIssueFiltersToMcpScopes(): void
+    {
+        // mcp 以外が混ざっても mcp:*:read だけが採用される
+        $this->mcpTokenService->issue($this->member, 'mixed', ['mcp:product:read', 'write'], 30);
+
+        $mcpToken = $this->mcpTokenRepository->findOneBy([], ['id' => 'DESC']);
+        $this->assertSame(['mcp:product:read'], $mcpToken->getScopes());
+    }
+
+    public function testIssueRejectsInvalidExpireDays(): void
+    {
+        // プリセット外の有効日数 (フォームバイパス) は発行できない
+        $this->expectException(\InvalidArgumentException::class);
+        $this->mcpTokenService->issue($this->member, 'bad-expire', ['mcp:product:read'], 9999);
+    }
+
+    /**
+     * `/admin/mcp` に initialize を投げ、 firewall の通過可否を見る (handshake の成否)。
+     */
+    private function mcpRequest(string $bearerJwt): void
+    {
+        $adminRoute = static::getContainer()->getParameter('eccube_admin_route');
+        $this->client->request(
+            Request::METHOD_POST,
+            '/'.$adminRoute.'/mcp',
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json, text/event-stream',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$bearerJwt,
+            ],
+            content: '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"t","version":"1"},"capabilities":{}}}',
+        );
+    }
+
+    private function ensureMcpPatClient(): void
+    {
+        /** @var ClientManagerInterface $clientManager */
+        $clientManager = static::getContainer()->get(ClientManagerInterface::class);
+        if (null !== $clientManager->find(McpTokenService::CLIENT_IDENTIFIER)) {
+            return;
+        }
+
+        $client = new Client('MCP PAT', McpTokenService::CLIENT_IDENTIFIER, null);
+        $client->setActive(true);
+        $client->setGrants(new Grant('authorization_code'));
+        $client->setScopes(...array_map(
+            static fn (string $scope): ScopeValue => new ScopeValue($scope),
+            McpTokenService::AVAILABLE_SCOPES,
+        ));
+        $clientManager->save($client);
+    }
+}

--- a/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
@@ -110,6 +110,10 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
 
         self::assertFalse(isset($callbackParams['error']));
         self::assertTrue(isset($callbackParams['code']));
+
+        // RFC 9207: 認可応答に issuer が付与される (AuthorizationResponseIssListener)
+        self::assertTrue(isset($callbackParams['iss']), '認可応答に iss が付与される');
+        self::assertStringContainsString($this->client->getRequest()->getHttpHost(), $callbackParams['iss']);
     }
 
     public function testRoutingAdminOauth2Authorize権限移譲を許可しない(): void

--- a/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
@@ -15,21 +15,38 @@ namespace Plugin\Api44\Tests\Web\Admin\OAuth2Bundle;
 
 use Eccube\Common\Constant;
 use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthorizationControllerTest extends AbstractAdminWebTestCase
 {
+    private ?Client $testClient = null;
+
     public function setUp(): void
     {
         parent::setUp();
+
+        // authorize の検証には redirectUris を持つ confidential client が必要。
+        // confidential (secret あり) のため PKCE 必須対象外で、 既存テストの code_challenge 無しフローが通る。
+        /** @var ClientManagerInterface $clientManager */
+        $clientManager = static::getContainer()->get(ClientManagerInterface::class);
+        $client = new Client('Authz Test', 'authztest', 'authztest-secret');
+        $client->setActive(true);
+        $client->setRedirectUris(new RedirectUri('http://127.0.0.1/callback'));
+        $client->setGrants(new Grant('authorization_code'), new Grant('refresh_token'));
+        $client->setScopes(new Scope('read'), new Scope('write'));
+        $clientManager->save($client);
+        $this->testClient = $client;
     }
 
     public function testRoutingAdminOauth2Authorizeログインしている場合は権限移譲確認画面を表示(): void
     {
-        /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->testClient;
 
         $this->client->request('GET',
             $this->generateUrl(
@@ -53,8 +70,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
 
     public function testRoutingAdminOauth2Authorize権限移譲を許可(): void
     {
-        /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->testClient;
         $authorize_url = $this->generateUrl(
             'oauth2_authorize',
             [
@@ -98,8 +114,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
 
     public function testRoutingAdminOauth2Authorize権限移譲を許可しない(): void
     {
-        /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->testClient;
         $authorize_url = $this->generateUrl(
             'oauth2_authorize',
             [
@@ -194,8 +209,7 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
         $this->assertTrue($response->isRedirection());
 
         // OAuth画面へ移動
-        /** @var Client $Client */
-        $Client = $this->entityManager->getRepository(Client::class)->findOneBy([]);
+        $Client = $this->testClient;
         $authorize_url = $this->generateUrl(
             'oauth2_authorize',
             [

--- a/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/AuthorizationControllerTest.php
@@ -159,6 +159,9 @@ class AuthorizationControllerTest extends AbstractAdminWebTestCase
 
         $callbackParams = $this->parseCallbackParams($response);
         self::assertEquals('access_denied', $callbackParams['error']);
+
+        // RFC 9207: エラー応答にも iss が付与される (AuthorizationResponseIssListener)
+        self::assertTrue(isset($callbackParams['iss']), 'エラー応答にも iss が付与される');
     }
 
     public function testRoutingAdminOauth2Authorize権限移譲を許可パラメータが足りない場合(): void

--- a/Tests/Web/Admin/OAuth2Bundle/PkceEnforcementTest.php
+++ b/Tests/Web/Admin/OAuth2Bundle/PkceEnforcementTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Web\Admin\OAuth2Bundle;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * PKCE(S256) 必須が「宣言」でなく「強制」として効いていることを挙動で縛る。
+ *
+ * secret を持たない public クライアントが code_challenge 無しで認可要求すると拒否されることを確認する。
+ * (config 値の assert では library 既定に頼っているだけかを区別できないため、 実挙動で確認する)
+ */
+class PkceEnforcementTest extends AbstractAdminWebTestCase
+{
+    public function testAuthorizeRejectsPublicClientWithoutCodeChallenge(): void
+    {
+        /** @var ClientManagerInterface $clientManager */
+        $clientManager = static::getContainer()->get(ClientManagerInterface::class);
+        // secret = null で public クライアント (DCR 発行クライアントと同型)
+        $client = new Client('Public No PKCE', 'publicnopkce', null);
+        $client->setActive(true);
+        $client->setRedirectUris(new RedirectUri('http://127.0.0.1/callback'));
+        $client->setGrants(new Grant('authorization_code'));
+        $client->setScopes(new Scope('read'));
+        $clientManager->save($client);
+
+        $this->client->request('GET', $this->generateUrl('oauth2_authorize', [
+            'client_id' => 'publicnopkce',
+            'redirect_uri' => 'http://127.0.0.1/callback',
+            'response_type' => 'code',
+            'scope' => 'read',
+            'state' => 'xxx',
+        ]));
+
+        $response = $this->client->getResponse();
+        // 同意画面 (200) には進まず、 league が PKCE 必須で invalid_request として弾く
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertSame('invalid_request', $data['error']);
+        $this->assertStringContainsString(
+            'Code challenge must be provided for public clients',
+            (string) ($data['hint'] ?? ''),
+        );
+    }
+}

--- a/Tests/Web/OAuthDiscoveryTest.php
+++ b/Tests/Web/OAuthDiscoveryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Web;
+
+use Eccube\Tests\EccubeTestCase;
+use Plugin\Api44\Service\McpTokenService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MCP OAuth ディスカバリ (.well-known / WWW-Authenticate / DCR) の契約テスト。
+ *
+ * クライアントが自動発見でき、 かつ公開エンドポイントが安全に縛られていることを実フローで担保する。
+ */
+class OAuthDiscoveryTest extends EccubeTestCase
+{
+    public function testProtectedResourceMetadataIsPublic(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/.well-known/oauth-protected-resource');
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertStringEndsWith('/mcp', $data['resource']);
+        $this->assertSame(McpTokenService::AVAILABLE_SCOPES, $data['scopes_supported']);
+        $this->assertNotEmpty($data['authorization_servers']);
+    }
+
+    public function testAuthorizationServerMetadataIsPublic(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/.well-known/oauth-authorization-server');
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertArrayHasKey('authorization_endpoint', $data);
+        $this->assertArrayHasKey('token_endpoint', $data);
+        $this->assertSame(['S256'], $data['code_challenge_methods_supported']);
+        $this->assertSame(['none'], $data['token_endpoint_auth_methods_supported']);
+        $this->assertStringEndsWith('/register', $data['registration_endpoint']);
+    }
+
+    public function testMcpUnauthorizedAdvertisesResourceMetadata(): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/'.$this->adminRoute().'/mcp',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: '{}',
+        );
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+
+        $header = (string) $response->headers->get('WWW-Authenticate');
+        $this->assertStringContainsString('resource_metadata=', $header);
+        $this->assertStringContainsString('/.well-known/oauth-protected-resource', $header);
+    }
+
+    public function testDcrRegistersLoopbackClientAndForcesScopeGrant(): void
+    {
+        // write / client_credentials を要求しても MCP read + authorization_code に固定されること
+        $this->client->request(
+            Request::METHOD_POST,
+            '/register',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode([
+                'client_name' => 'contract-test',
+                'redirect_uris' => ['http://127.0.0.1:3334/oauth/callback'],
+                'grant_types' => ['authorization_code', 'client_credentials'],
+                'scope' => 'mcp:product:read write',
+            ]),
+        );
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertNotEmpty($data['client_id']);
+        $this->assertSame(['authorization_code', 'refresh_token'], $data['grant_types']);
+        $this->assertSame(implode(' ', McpTokenService::AVAILABLE_SCOPES), $data['scope']);
+        $this->assertSame('none', $data['token_endpoint_auth_method']);
+    }
+
+    public function testDcrRejectsNonLoopbackHttpRedirect(): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/register',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['redirect_uris' => ['http://evil.example.com/cb']]),
+        );
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testDcrRejectsParserDifferentialRedirect(): void
+    {
+        // PHP parse_url は host=localhost と解釈するが、 ブラウザ (WHATWG) は evil.com に飛ぶ。
+        // パーサ差異による host 詐称を fail-closed で拒否すること。
+        $this->client->request(
+            Request::METHOD_POST,
+            '/register',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: (string) json_encode(['redirect_uris' => ['http://evil.com\\@localhost/cb']]),
+        );
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    private function adminRoute(): string
+    {
+        return (string) static::getContainer()->getParameter('eccube_admin_route');
+    }
+}

--- a/Tests/Web/OAuthDiscoveryTest.php
+++ b/Tests/Web/OAuthDiscoveryTest.php
@@ -51,22 +51,6 @@ class OAuthDiscoveryTest extends EccubeTestCase
         $this->assertStringEndsWith('/register', $data['registration_endpoint']);
     }
 
-    public function testMcpUnauthorizedAdvertisesResourceMetadata(): void
-    {
-        $this->client->request(
-            Request::METHOD_POST,
-            '/'.$this->adminRoute().'/mcp',
-            server: ['CONTENT_TYPE' => 'application/json'],
-            content: '{}',
-        );
-        $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
-
-        $header = (string) $response->headers->get('WWW-Authenticate');
-        $this->assertStringContainsString('resource_metadata=', $header);
-        $this->assertStringContainsString('/.well-known/oauth-protected-resource', $header);
-    }
-
     public function testDcrRegistersLoopbackClientAndForcesScopeGrant(): void
     {
         // write / client_credentials を要求しても MCP read + authorization_code に固定されること
@@ -113,10 +97,5 @@ class OAuthDiscoveryTest extends EccubeTestCase
             content: (string) json_encode(['redirect_uris' => ['http://evil.com\\@localhost/cb']]),
         );
         $this->assertSame(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
-    }
-
-    private function adminRoute(): string
-    {
-        return (string) static::getContainer()->getParameter('eccube_admin_route');
     }
 }


### PR DESCRIPTION
- scopes.available に mcp:product:read / mcp:order:read / mcp:customer:read / mcp:plugin:read を追加 (本体同梱の MCP サーバ機能の領域別 read scope。 GraphQL の read/write とは名前空間 mcp: で分離)
- ApiExtension::prepend で ^/<admin>/mcp 用の OAuth2 stateless firewall を admin の前に注入 (本体側 Tool の IsGranted と AND 評価で認可)
- ApiExtensionTest: firewall 順序 / shape / 既存 admin/customer の csrf_token_generator・anonymous 削除を検証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理画面でMCPトークンの発行・失効、一覧表示ができるようになりました。
  * 動的クライアント登録と公開メタデータ取得のエンドポイントを追加しました。
  * 未使用のDCRクライアントを定期的に整理するコマンドを追加しました。
* **改善**
  * OAuth管理画面でMCP関連クライアントを分離表示するようにしました。
  * 公開用の認証設定とリダイレクト先検証を強化しました。
* **ドキュメント/表示**
  * MCPトークン、スコープ、失効に関する表示文言を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->