### PR TITLE
feat(agent-commerce): エージェントコマース用 OAuth2（client_credentials / scope / AccessTokenHandler / クライアント登録導線）を追加 (#188)

### DIFF
--- a/Controller/Admin/AgentCommerceClientController.php
+++ b/Controller/Admin/AgentCommerceClientController.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Controller\Admin;
+
+use Eccube\Controller\AbstractController;
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
+use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Form\Type\Admin\AgentCommerceClientType;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * エージェントコマース (ACP/UCP) 用 OAuth2 クライアントの登録画面 (#188)。
+ *
+ * protocol ごとに入口を分ける理由は {@link AgentCommerceClientType} を参照。
+ * grant は client_credentials 固定、 scope は protocol のものだけを付与する。
+ */
+class AgentCommerceClientController extends AbstractController
+{
+    public function __construct(
+        private readonly ClientManagerInterface $clientManager,
+    ) {
+    }
+
+    #[Route(path: '/%eccube_admin_route%/api/oauth/acp/new', name: 'admin_api_oauth_acp_new', methods: ['GET', 'POST'])]
+    public function createAcp(Request $request): RedirectResponse|Response
+    {
+        return $this->createClient($request, 'acp');
+    }
+
+    #[Route(path: '/%eccube_admin_route%/api/oauth/ucp/new', name: 'admin_api_oauth_ucp_new', methods: ['GET', 'POST'])]
+    public function createUcp(Request $request): RedirectResponse|Response
+    {
+        return $this->createClient($request, 'ucp');
+    }
+
+    private function createClient(Request $request, string $protocol): RedirectResponse|Response
+    {
+        $form = $this->createForm(AgentCommerceClientType::class, null, ['protocol' => $protocol]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $client = new Client(
+                    (string) $form->get('name')->getData(),
+                    (string) $form->get('identifier')->getData(),
+                    (string) $form->get('secret')->getData()
+                );
+                $client->setActive(true);
+                // エージェントは会員でもブラウザでもなく同意画面を経由できないため、 M2M の
+                // client_credentials に固定する (authorization_code / refresh_token は付与しない)。
+                $client->setGrants(new Grant(OAuth2Grants::CLIENT_CREDENTIALS));
+                $client->setScopes(...array_map(
+                    static fn (string $scope): Scope => new Scope($scope),
+                    $form->get('scopes')->getData()
+                ));
+
+                $this->clientManager->save($client);
+
+                $this->addSuccess('admin.common.save_complete', 'admin');
+
+                // league はシークレットを保存時にハッシュ化せず、 初回のトークン取得成功時に
+                // bcrypt へ日和見アップグレードする (ClientRepository::validateClient)。
+                // つまり一度使われた後の一覧表示はハッシュ値で、 事業者へ渡す値を復元できない。
+                // 発行直後のこの画面でだけ平文を提示する (redirect すると失われるため render する)。
+                $response = $this->render('@Api44/admin/OAuth/agent_commerce_client_issued.twig', [
+                    'name' => (string) $form->get('name')->getData(),
+                    'identifier' => (string) $form->get('identifier')->getData(),
+                    'secret' => (string) $form->get('secret')->getData(),
+                ]);
+                // 認証情報を HTML に埋め込む画面なので、 ブラウザや共有端末のキャッシュに残さない
+                $response->headers->set('Cache-Control', 'no-store, private');
+
+                return $response;
+            } catch (\Exception $e) {
+                $this->addError(trans('admin.common.save_error'), 'admin');
+                log_error('エージェントコマース OAuth2 Client 登録エラー', ['exception' => $e, 'protocol' => $protocol]);
+            }
+        }
+
+        return $this->render('@Api44/admin/OAuth/agent_commerce_client.twig', [
+            'form' => $form->createView(),
+            'protocol' => $protocol,
+        ]);
+    }
+}

--- a/Controller/Admin/OAuthController.php
+++ b/Controller/Admin/OAuthController.php
@@ -25,6 +25,7 @@ use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Grant;
 use League\Bundle\OAuth2ServerBundle\ValueObject\RedirectUri;
 use League\Bundle\OAuth2ServerBundle\ValueObject\Scope;
+use Plugin\Api44\Form\Type\Admin\AgentCommerceClientType;
 use Plugin\Api44\Form\Type\Admin\ClientType;
 use Plugin\Api44\Repository\McpTokenRepository;
 use Plugin\Api44\Service\McpTokenService;
@@ -86,6 +87,13 @@ class OAuthController extends AbstractController
         return $this->render('@Api44/admin/OAuth/index.twig', [
             'clients' => $clients,
             'mcpTokens' => $this->mcpTokenRepository->findAllOrderByCreateDate(),
+            // エージェントコマース用クライアントのシークレットは一覧で再表示しない (#188)。
+            // league は初回のトークン取得成功時に保存値を bcrypt へ差し替えるため、 一覧の値は
+            // そのまま事業者へ渡せない。 平文は発行直後の画面でだけ提示する。
+            'agentCommerceClientIds' => array_values(array_map(
+                static fn (ClientInterface $client): string => $client->getIdentifier(),
+                array_filter($clients, self::isAgentCommerceClient(...))
+            )),
         ]);
     }
 
@@ -99,8 +107,6 @@ class OAuthController extends AbstractController
     #[Route(path: '/%eccube_admin_route%/api/oauth/new', name: 'admin_api_oauth_new', methods: ['GET', 'POST'])]
     public function create(Request $request): RedirectResponse|Response
     {
-        $name = '';
-
         $builder = $this->formFactory
             ->createBuilder(ClientType::class);
 
@@ -108,6 +114,7 @@ class OAuthController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $name = (string) $form->get('name')->getData();
             $identifier = $form->get('identifier')->getData();
             $secret = $form->get('secret')->getData();
 
@@ -182,6 +189,29 @@ class OAuthController extends AbstractController
         }
 
         return $this->redirectToRoute('admin_api_oauth');
+    }
+
+    /**
+     * エージェントコマース (ACP/UCP) 用に発行されたクライアントか判定する.
+     *
+     * scope の protocol 接頭辞で判定する ({@link AgentCommerceClientType} が付与する scope)。
+     */
+    private static function isAgentCommerceClient(ClientInterface $client): bool
+    {
+        $prefixes = array_map(
+            static fn (string $protocol): string => $protocol.':',
+            array_keys(AgentCommerceClientType::PROTOCOL_SCOPES)
+        );
+
+        foreach ($client->getScopes() as $scope) {
+            foreach ($prefixes as $prefix) {
+                if (str_starts_with((string) $scope, $prefix)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/Form/Type/Admin/AgentCommerceClientType.php
+++ b/Form/Type/Admin/AgentCommerceClientType.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Form\Type\Admin;
+
+use Eccube\Common\EccubeConfig;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * エージェントコマース (ACP/UCP) 用 OAuth2 クライアントの登録フォーム (#188)。
+ *
+ * 汎用の {@link ClientType} と分けているのは、 エージェントコマースでは grant と scope の
+ * 組み合わせが一意に決まるためである。 エージェントは会員でもブラウザでもないので同意画面を
+ * 経由できず、 grant は client_credentials 固定・redirect_uri は不使用になる。 汎用フォームで
+ * 全 scope と全 grant を並べると、 成立しない組み合わせ (例: acp:checkout × authorization_code)
+ * を作れてしまうため、 protocol ごとに入口を分けて画面側で整合を保証する。
+ *
+ * 1 クライアントに ACP と UCP を混在させないのも本フォームの目的である。 受注に記録される
+ * `Order.agent_id` は OAuth2 クライアント識別子なので、 事業者ごとにクライアントを分けないと
+ * 受注の帰属・失効・レート制御を事業者単位で扱えない。
+ */
+class AgentCommerceClientType extends AbstractType
+{
+    /**
+     * protocol => この画面から付与できる scope。
+     *
+     * `Resource/config/services.yaml` の `scopes.available` と同期させること
+     * (league は available に無い scope を拒否する)。
+     *
+     * `ucp:identity` は**意図的に含めない**。 会員本人の同意のもとで発行する capability であり、
+     * Customer を subject とする authorization_code が前提になるため client_credentials では
+     * 成立しない (eccube-api4#189)。 #189 landing 後に会員同意を伴う別導線として追加する。
+     *
+     * @var array<string, list<string>>
+     */
+    public const PROTOCOL_SCOPES = [
+        'acp' => ['acp:checkout', 'acp:catalog'],
+        'ucp' => ['ucp:checkout', 'ucp:cart', 'ucp:catalog'],
+    ];
+
+    public function __construct(
+        private readonly EccubeConfig $eccubeConfig,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $scopes = self::PROTOCOL_SCOPES[$options['protocol']];
+
+        $builder
+            // どのエージェント事業者向けのクライアントかを後から追えるようにする (Client::name)
+            ->add('name', TextType::class, [
+                'mapped' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                ],
+            ])
+            ->add('identifier', TextType::class, [
+                'mapped' => false,
+                'data' => hash('md5', random_bytes(16)),
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => 32]),
+                    new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
+                ],
+            ])
+            ->add('secret', TextType::class, [
+                'mapped' => false,
+                'data' => hash('sha512', random_bytes(32)),
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => 128]),
+                    new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
+                ],
+            ])
+            ->add('scopes', ChoiceType::class, [
+                'choices' => array_combine($scopes, $scopes),
+                'expanded' => true,
+                'multiple' => true,
+                'mapped' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    // choices 外の scope をフォームバイパスで送っても弾く
+                    new Assert\All([new Assert\Choice(['choices' => $scopes])]),
+                ],
+            ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setRequired('protocol');
+        $resolver->setAllowedValues('protocol', array_keys(self::PROTOCOL_SCOPES));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'api_admin_agent_commerce_client';
+    }
+}

--- a/Form/Type/Admin/AgentCommerceClientType.php
+++ b/Form/Type/Admin/AgentCommerceClientType.php
@@ -90,7 +90,9 @@ class AgentCommerceClientType extends AbstractType
                 'data' => hash('sha512', random_bytes(32)),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => 128]),
+                    // client_credentials ではシークレットが唯一の認証情報なので下限を設ける
+                    // (既定値は sha512 hex = 128 文字なので、 手で書き換えた場合にだけ効く)。
+                    new Assert\Length(['min' => 32, 'max' => 128]),
                     new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
                 ],
             ])
@@ -101,7 +103,10 @@ class AgentCommerceClientType extends AbstractType
                 'mapped' => false,
                 'constraints' => [
                     new Assert\NotBlank(),
-                    // choices 外の scope をフォームバイパスで送っても弾く
+                    // choices 外の scope を弾いているのは実際には ChoiceType 自身である。
+                    // PRE_SUBMIT で未知値を submitted data から除去し、 POST_SUBMIT で FormError を
+                    // 積む (`ChoiceType::buildForm()`)。 本制約はその機構に依存しないための多層防御で、
+                    // 制約評価時にはデータが choices 済みに絞られているため通常は発火しない。
                     new Assert\All([new Assert\Choice(['choices' => $scopes])]),
                 ],
             ]);

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -69,7 +69,9 @@ class ClientType extends AbstractType
                 'data' => hash('sha512', random_bytes(32)),
                 'constraints' => [
                     new Assert\NotBlank(),
-                    new Assert\Length(['max' => 128]),
+                    // confidential クライアントは token エンドポイントの認証材料がシークレットのみ
+                    // なので下限を設ける ({@link AgentCommerceClientType} と同条件)。
+                    new Assert\Length(['min' => 32, 'max' => 128]),
                     new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
                 ],
             ])

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -47,6 +47,14 @@ class ClientType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            // 一覧でクライアントの用途を識別できるようにする (Client::name)
+            ->add('name', TextType::class, [
+                'mapped' => false,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Length(['max' => $this->eccubeConfig['eccube_stext_len']]),
+                ],
+            ])
             ->add('identifier', TextType::class, [
                 'mapped' => false,
                 'data' => hash('md5', random_bytes(16)),
@@ -65,17 +73,13 @@ class ClientType extends AbstractType
                     new Assert\Regex(['pattern' => '/^[0-9a-zA-Z]+$/']),
                 ],
             ])
+            // エージェントコマース (ACP/UCP) の scope はここに並べない。 grant と scope の
+            // 組み合わせが protocol ごとに決まるため、 専用の登録導線
+            // ({@link AgentCommerceClientType}) から付与する (#188)。
             ->add('scopes', ChoiceType::class, [
                 'choices' => [
                     'read' => 'read',
                     'write' => 'write',
-                    // エージェントコマース (ACP/UCP) 用 scope (#188・<protocol>:<capability> 規約)
-                    'acp:checkout' => 'acp:checkout',
-                    'acp:catalog' => 'acp:catalog',
-                    'ucp:checkout' => 'ucp:checkout',
-                    'ucp:cart' => 'ucp:cart',
-                    'ucp:catalog' => 'ucp:catalog',
-                    'ucp:identity' => 'ucp:identity',
                 ],
                 'expanded' => true,
                 'multiple' => true,
@@ -92,11 +96,11 @@ class ClientType extends AbstractType
                     new Assert\Url(),
                 ],
             ])
+            // client_credentials はエージェントコマース専用の登録導線で固定付与するため、
+            // 汎用フォームでは選ばせない (#188)。
             ->add('grants', ChoiceType::class, [
                 'choices' => [
                     'Authorization code' => OAuth2Grants::AUTHORIZATION_CODE,
-                    // エージェントコマースの machine-to-machine 認証用 (#188)
-                    'Client credentials' => OAuth2Grants::CLIENT_CREDENTIALS,
                 ],
                 'expanded' => true,
                 'multiple' => true,

--- a/Form/Type/Admin/ClientType.php
+++ b/Form/Type/Admin/ClientType.php
@@ -69,6 +69,13 @@ class ClientType extends AbstractType
                 'choices' => [
                     'read' => 'read',
                     'write' => 'write',
+                    // エージェントコマース (ACP/UCP) 用 scope (#188・<protocol>:<capability> 規約)
+                    'acp:checkout' => 'acp:checkout',
+                    'acp:catalog' => 'acp:catalog',
+                    'ucp:checkout' => 'ucp:checkout',
+                    'ucp:cart' => 'ucp:cart',
+                    'ucp:catalog' => 'ucp:catalog',
+                    'ucp:identity' => 'ucp:identity',
                 ],
                 'expanded' => true,
                 'multiple' => true,
@@ -88,6 +95,8 @@ class ClientType extends AbstractType
             ->add('grants', ChoiceType::class, [
                 'choices' => [
                     'Authorization code' => OAuth2Grants::AUTHORIZATION_CODE,
+                    // エージェントコマースの machine-to-machine 認証用 (#188)
+                    'Client credentials' => OAuth2Grants::CLIENT_CREDENTIALS,
                 ],
                 'expanded' => true,
                 'multiple' => true,

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -12,7 +12,8 @@ league_oauth2_server:
         encryption_key: '%env(ECCUBE_OAUTH2_ENCRYPTION_KEY)%'
 
       # Whether to enable the client credentials grant
-        enable_client_credentials_grant: false
+      # エージェントコマース (ACP/UCP) の machine-to-machine インバウンド認証で使用する (#188)。
+        enable_client_credentials_grant: true
 
       # Whether to enable the password grant
         enable_password_grant: false
@@ -30,13 +31,22 @@ league_oauth2_server:
         public_key: '%env(ECCUBE_OAUTH2_RESOURCE_SERVER_PUBLIC_KEY)%'
 
     scopes:
-        available: ['read', 'write']
+      # read/write は GraphQL API 用。acp:*/ucp:* はエージェントコマース (#188・<protocol>:<capability> 規約)。
+        available: ['read', 'write', 'acp:checkout', 'acp:catalog', 'ucp:checkout', 'ucp:cart', 'ucp:catalog', 'ucp:identity']
         default: ['read']
 
     persistence:
         doctrine: null
 
 services:
+    # エージェントコマース (#188): EC-CUBE 本体の AgentCommerceOAuth2Authenticator が依存する
+    # Symfony 標準 AccessTokenHandlerInterface を提供する。league の ResourceServer で
+    # Bearer トークン (JWT) を検証 (公開鍵での署名/期限/失効) し、付与 scope を UserBadge の
+    # attributes['scopes'] に載せて返す。本体は handler が無ければ 503 を返す疎結合設計。
+    Plugin\Api44\Security\AgentCommerceAccessTokenHandler:
+        autowire: true
+    Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface: '@Plugin\Api44\Security\AgentCommerceAccessTokenHandler'
+
     Plugin\Api44\EventListener\UserResolveListener:
         arguments:
             - '@Eccube\Security\Core\User\MemberProvider'

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -88,6 +88,12 @@ services:
     # Symfony 標準 AccessTokenHandlerInterface を提供する。league の ResourceServer で
     # Bearer トークン (JWT) を検証 (公開鍵での署名/期限/失効) し、付与 scope を UserBadge の
     # attributes['scopes'] に載せて返す。本体は handler が無ければ 503 を返す疎結合設計。
+    #
+    # 注意: 下の alias はアプリ全体に効く (この ID で解決されるサービスは常に 1 つだけ)。
+    # 将来 access_token firewall や他プラグインが同インターフェイスを autowire / alias すると、
+    # 無言で本ハンドラに解決される、 あるいは alias が上書きされて ACP 側が壊れる。
+    # 実例: EC-CUBE 本体の app/config/eccube/services_test.yaml は同じ ID にテスト用スタブを
+    # 登録するため、 本プラグインを入れた環境では本体側テストの解決先が入れ替わる。
     Plugin\Api44\Security\AgentCommerceAccessTokenHandler:
         autowire: true
     Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface: '@Plugin\Api44\Security\AgentCommerceAccessTokenHandler'

--- a/Resource/locale/messages.en.yaml
+++ b/Resource/locale/messages.en.yaml
@@ -12,10 +12,13 @@ api:
       token_endpoint: Token endpoint
       api_endpoint: API endpoint
       management: OAuth
+      name: Name
+      name_tooltip: 'A name describing what this client is used for (e.g. stock sync batch)'
       identifier: Client ID
       identifier_tooltip: Up to 32 alphanumeric characters
       secret: Client Secret
       secret_tooltip: Up to 128 alphanumeric characters
+      secret_none_tooltip: 'This client has no secret (public client).'
       scope: Scope
       scope_tooltip: GraphQL Query requires read, Mutation requires write/write Scope
       scope.read.description: 'Read %shop_name% data'
@@ -56,6 +59,21 @@ api:
       mcp_token.revoke__confirm_title: Revoke MCP token
       mcp_token.revoke__confirm_message: Are you sure you want to revoke this token? It will stop working immediately.
       mcp_token.revoke__not_found: The token to revoke was not found (it may already be revoked or expired). It has been removed from the list.
+      agent_commerce.acp_registration__new: New ACP client
+      agent_commerce.ucp_registration__new: New UCP client
+      agent_commerce.acp_registration: ACP client registration
+      agent_commerce.ucp_registration: UCP client registration
+      agent_commerce.acp_description: 'Register a client for an agent provider that checks out with ACP (Agentic Commerce Protocol). Register one client per provider (the agent_id recorded on orders is this client ID).'
+      agent_commerce.ucp_description: 'Register a client for an agent provider that checks out with UCP (Universal Commerce Protocol). Register one client per provider (the agent_id recorded on orders is this client ID).'
+      agent_commerce.acp_name_tooltip: 'A name identifying the agent provider this client is for (e.g. ChatGPT)'
+      agent_commerce.ucp_name_tooltip: 'A name identifying the agent provider this client is for (e.g. Gemini)'
+      agent_commerce.acp_scope_tooltip: 'acp:checkout is required for checkout (create, update and complete orders); acp:catalog for reading catalog data.'
+      agent_commerce.ucp_scope_tooltip: 'ucp:checkout is required for checkout (create, update and complete orders); ucp:cart for cart operations; ucp:catalog for reading catalog data. ucp:identity (member ID linking) requires the member''s own consent and cannot be granted on this screen.'
+      agent_commerce.grant_note: 'Agents do not go through a consent screen, so the grant is fixed to client_credentials (machine-to-machine). Redirect URIs are not used.'
+      agent_commerce.secret_note: 'The client secret is shown only once on the confirmation screen after registration. It cannot be shown again from the list, so copy and store it securely.'
+      agent_commerce.secret_hidden_tooltip: 'The client secret is shown only on the screen right after registration (it cannot be shown again).'
+      agent_commerce.issued_title: Agentic commerce client registered
+      agent_commerce.issued_warning: 'The client secret is shown only once on this screen. Copy and store it securely (it cannot be shown again).'
     webhook:
       management:  WebHook
       registration: WebHook Registration

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -12,10 +12,13 @@ api:
       token_endpoint: Token endpoint
       api_endpoint: API endpoint
       management: OAuth管理
+      name: 名称
+      name_tooltip: 'このクライアントの用途がわかる名前（例: 在庫連携バッチ）'
       identifier: クライアントID
       identifier_tooltip: 32文字以下の半角英数
       secret: クライアントシークレット
       secret_tooltip: 128文字以下の半角英数
+      secret_none_tooltip: 'このクライアントはシークレットを持ちません（public client）。'
       scope: スコープ
       scope_tooltip: GraphQLのQueryにはread, Mutationにはwrite/writeのScopeが必要
       scope.read.description: '%shop_name%のデータに対する読み取り'
@@ -56,6 +59,21 @@ api:
       mcp_token.revoke__confirm_title: MCP トークンを失効します
       mcp_token.revoke__confirm_message: このトークンを失効してよろしいですか？ 失効すると即座に利用できなくなります。
       mcp_token.revoke__not_found: 失効対象のトークンが見つかりませんでした（既に失効・期限切れの可能性）。 一覧からは削除しました。
+      agent_commerce.acp_registration__new: ACP 新規追加
+      agent_commerce.ucp_registration__new: UCP 新規追加
+      agent_commerce.acp_registration: ACP クライアント登録
+      agent_commerce.ucp_registration: UCP クライアント登録
+      agent_commerce.acp_description: 'ACP (Agentic Commerce Protocol) でチェックアウトするエージェント事業者向けのクライアントを登録します。 事業者ごとに 1 つ登録してください（受注に記録される agent_id はこのクライアントIDです）。'
+      agent_commerce.ucp_description: 'UCP (Universal Commerce Protocol) でチェックアウトするエージェント事業者向けのクライアントを登録します。 事業者ごとに 1 つ登録してください（受注に記録される agent_id はこのクライアントIDです）。'
+      agent_commerce.acp_name_tooltip: 'どのエージェント事業者向けのクライアントかがわかる名前（例: ChatGPT）'
+      agent_commerce.ucp_name_tooltip: 'どのエージェント事業者向けのクライアントかがわかる名前（例: Gemini）'
+      agent_commerce.acp_scope_tooltip: 'acp:checkout はチェックアウト（注文の作成・更新・確定）、 acp:catalog はカタログデータの読み取りに必要です。'
+      agent_commerce.ucp_scope_tooltip: 'ucp:checkout はチェックアウト（注文の作成・更新・確定）、 ucp:cart はカート操作、 ucp:catalog はカタログデータの読み取りに必要です。 ucp:identity（会員 ID 連携）は会員本人の同意が必要なため、 この画面では付与できません。'
+      agent_commerce.grant_note: 'エージェントは同意画面を経由しないため、 機械間（M2M）認証の client_credentials に固定されます。 リダイレクトURIは使用しません。'
+      agent_commerce.secret_note: 'クライアントシークレットは登録完了画面で 1 度だけ表示されます。 一覧では再表示できないため、 コピーして安全に保管してください。'
+      agent_commerce.secret_hidden_tooltip: 'クライアントシークレットは登録完了画面でのみ表示されます（再表示不可）。'
+      agent_commerce.issued_title: エージェントコマース用クライアントを登録しました
+      agent_commerce.issued_warning: 'クライアントシークレットは今この画面でのみ表示されます。 コピーして安全に保管してください（再表示はできません）。'
     webhook:
       management:  WebHook管理
       registration: WebHook登録

--- a/Resource/template/admin/OAuth/agent_commerce_client.twig
+++ b/Resource/template/admin/OAuth/agent_commerce_client.twig
@@ -12,13 +12,13 @@ file that was distributed with this source code.
 
 {% set menus = ['setting', 'api', 'oauth'] %}
 
-{% block title %}{{ 'api.admin.oauth.client_registration'|trans }}{% endblock %}
+{% block title %}{{ ('api.admin.oauth.agent_commerce.' ~ protocol ~ '_registration')|trans }}{% endblock %}
 {% block sub_title %}{{ 'api.admin.management'|trans }}{% endblock %}
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
 {% block main %}
-    <form name="client_form" role="form" id="client_form" method="post" action="" novalidate>
+    <form name="agent_commerce_client_form" role="form" id="agent_commerce_client_form" method="post" action="" novalidate>
         {{ form_widget(form._token) }}
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
@@ -27,17 +27,19 @@ file that was distributed with this source code.
                         <div class="card-header">
                             <div class="row">
                                 <div class="col-8">
-                                    <span class="card-title">{{ 'api.admin.oauth.client_registration'|trans }}</span>
+                                    <span class="card-title">{{ ('api.admin.oauth.agent_commerce.' ~ protocol ~ '_registration')|trans }}</span>
                                 </div>
                             </div>
                         </div>
-                        <div class="collapse show ec-cardCollapse" id="clientInfo">
+                        <div class="collapse show ec-cardCollapse" id="agentCommerceClientInfo">
                             <div class="card-body">
+
+                                <p class="text-muted">{{ ('api.admin.oauth.agent_commerce.' ~ protocol ~ '_description')|trans }}</p>
 
                                 {# name #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.name_tooltip'|trans }}">
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ ('api.admin.oauth.agent_commerce.' ~ protocol ~ '_name_tooltip')|trans }}">
                                             <span>{{ 'api.admin.oauth.name'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ms-1"></i>
                                             <span class="badge bg-primary ms-1">
@@ -91,6 +93,7 @@ file that was distributed with this source code.
                                         <div class="row">
                                             <div class="col">
                                                 {{ form_widget(form.secret) }}
+                                                <p class="text-muted mb-0">{{ 'api.admin.oauth.agent_commerce.secret_note'|trans }}</p>
                                             </div>
                                             {{ form_errors(form.secret) }}
                                         </div>
@@ -100,7 +103,7 @@ file that was distributed with this source code.
                                 {# scope #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.scope_tooltip'|trans }}">
+                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ ('api.admin.oauth.agent_commerce.' ~ protocol ~ '_scope_tooltip')|trans }}">
                                             <span>{{ 'api.admin.oauth.scope'|trans }}</span>
                                             <i class="fa fa-question-circle fa-lg ms-1"></i>
                                             <span class="badge bg-primary ms-1">
@@ -118,44 +121,19 @@ file that was distributed with this source code.
                                     </div>
                                 </div>
 
-                                {# redirect_uri #}
+                                {# grant type (固定のため表示のみ) #}
                                 <div class="row mb-2">
                                     <div class="col-3">
-                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.redirect_uri_tooltip'|trans }}">
-                                            <span>{{ 'api.admin.oauth.redirect_uri'|trans }}</span>
-                                            <i class="fa fa-question-circle fa-lg ms-1"></i>
-                                            <span class="badge bg-primary ms-1">
-                                                {{ 'admin.common.required'|trans }}
-                                            </span>
-                                        </label>
-                                    </div>
-                                    <div class="col">
-                                        <div class="row">
-                                            <div class="col">
-                                                {{ form_widget(form.redirect_uris) }}
-                                            </div>
-                                            {{ form_errors(form.redirect_uris) }}
-                                        </div>
-                                    </div>
-                                </div>
-
-                                {# grant_type #}
-                                <div class="row mb-2">
-                                    <div class="col-3">
-                                        <label class="col-form-label" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.grant_type_tooltip'|trans }}">
+                                        <label class="col-form-label">
                                             <span>{{ 'api.admin.oauth.grant_type'|trans }}</span>
-                                            <i class="fa fa-question-circle fa-lg ms-1"></i>
-                                            <span class="badge bg-primary ms-1">
-                                                {{ 'admin.common.required'|trans }}
-                                            </span>
                                         </label>
                                     </div>
                                     <div class="col">
                                         <div class="row">
-                                            <div class="col">
-                                                {{ form_widget(form.grants, {'label_attr': {'class': 'checkbox-inline'}}) }}
+                                            <div class="col col-form-label">
+                                                <span>Client credentials</span>
+                                                <p class="text-muted mb-0">{{ 'api.admin.oauth.agent_commerce.grant_note'|trans }}</p>
                                             </div>
-                                            {{ form_errors(form.grants, {'label_attr': {'class': 'checkbox-inline'}}) }}
                                         </div>
                                     </div>
                                 </div>

--- a/Resource/template/admin/OAuth/agent_commerce_client_issued.twig
+++ b/Resource/template/admin/OAuth/agent_commerce_client_issued.twig
@@ -74,7 +74,16 @@ file that was distributed with this source code.
         document.getElementById('agent_commerce_client_secret_copy').addEventListener('click', function () {
             const textarea = document.getElementById('agent_commerce_client_secret');
             textarea.select();
-            navigator.clipboard.writeText(textarea.value);
+            // navigator.clipboard は secure context 以外では undefined になり、
+            // そのまま呼ぶと TypeError で無言のコピー失敗になる。
+            // 一覧画面 (index.twig) と同じ document.execCommand をフォールバックに持つ。
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(textarea.value).catch(function () {
+                    document.execCommand('copy');
+                });
+            } else {
+                document.execCommand('copy');
+            }
         });
     </script>
 {% endblock %}

--- a/Resource/template/admin/OAuth/agent_commerce_client_issued.twig
+++ b/Resource/template/admin/OAuth/agent_commerce_client_issued.twig
@@ -1,0 +1,80 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+http://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+#}
+{% extends '@admin/default_frame.twig' %}
+
+{% set menus = ['setting', 'api', 'oauth'] %}
+
+{% block title %}{{ 'api.admin.oauth.agent_commerce.issued_title'|trans }}{% endblock %}
+{% block sub_title %}{{ 'api.admin.management'|trans }}{% endblock %}
+
+{% block main %}
+    <div class="c-contentsArea__cols">
+        <div class="c-contentsArea__primaryCol">
+            <div class="c-primaryCol">
+                <div class="card rounded border-0 mb-4">
+                    <div class="card-header">
+                        <span class="card-title">{{ 'api.admin.oauth.agent_commerce.issued_title'|trans }}{% if name %} ({{ name }}){% endif %}</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="alert alert-warning" role="alert">
+                            {{ 'api.admin.oauth.agent_commerce.issued_warning'|trans }}
+                        </div>
+                        <div class="row mb-2">
+                            <div class="col-3">
+                                <label class="col-form-label" for="agent_commerce_client_id">{{ 'api.admin.oauth.identifier'|trans }}</label>
+                            </div>
+                            <div class="col">
+                                <input type="text" id="agent_commerce_client_id" class="form-control" value="{{ identifier }}" readonly>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-3">
+                                <label class="col-form-label" for="agent_commerce_client_secret">{{ 'api.admin.oauth.secret'|trans }}</label>
+                            </div>
+                            <div class="col">
+                                <textarea id="agent_commerce_client_secret" class="form-control" rows="3" readonly>{{ secret }}</textarea>
+                            </div>
+                            <div class="col-auto">
+                                <button type="button" class="btn btn-ec-regular" id="agent_commerce_client_secret_copy">
+                                    {{ 'api.admin.oauth.copy'|trans }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="c-conversionArea">
+        <div class="c-conversionArea__container">
+            <div class="row justify-content-between align-items-center">
+                <div class="col-6">
+                    <div class="c-conversionArea__leftBlockItem">
+                        <a class="c-baseLink" href="{{ url('admin_api_oauth') }}">
+                            <i class="fa fa-backward" aria-hidden="true"></i>
+                            <span>{{ 'api.admin.oauth.management'|trans }}</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        document.getElementById('agent_commerce_client_secret_copy').addEventListener('click', function () {
+            const textarea = document.getElementById('agent_commerce_client_secret');
+            textarea.select();
+            navigator.clipboard.writeText(textarea.value);
+        });
+    </script>
+{% endblock %}

--- a/Resource/template/admin/OAuth/index.twig
+++ b/Resource/template/admin/OAuth/index.twig
@@ -80,12 +80,27 @@ file that was distributed with this source code.
                 <div id="create-client" class="d-block mb-3">
                     <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_new') }}">{{ 'api.admin.oauth.api_registration__new'|trans }}</a>
                     <a class="btn btn-ec-regular" href="{{ url('admin_api_mcp_token_new') }}">{{ 'api.admin.oauth.mcp_token.registration__new'|trans }}</a>
+                    <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_acp_new') }}">{{ 'api.admin.oauth.agent_commerce.acp_registration__new'|trans }}</a>
+                    <a class="btn btn-ec-regular" href="{{ url('admin_api_oauth_ucp_new') }}">{{ 'api.admin.oauth.agent_commerce.ucp_registration__new'|trans }}</a>
                 </div>
                 <div class="card rounded border-0 mb-4">
                     <div class="card-body p-0">
                         <table class="table table-sm" style="table-layout:fixed;">
+                            {# 列を追加したことで既定の等分割では見出しが折り返すため、 幅を明示する #}
+                            <colgroup>
+                                <col style="width:13%">
+                                <col style="width:17%">
+                                <col style="width:16%">
+                                <col style="width:16%">
+                                <col style="width:16%">
+                                <col style="width:15%">
+                                <col style="width:7%">
+                            </colgroup>
                             <thead>
                             <tr>
+                                <th class="border-top-0 pt-2 pb-2 text-center">
+                                    {{ 'api.admin.oauth.name'|trans }}
+                                </th>
                                 <th class="border-top-0 pt-2 pb-2 text-center">
                                     {{ 'api.admin.oauth.identifier'|trans }}
                                 </th>
@@ -107,11 +122,20 @@ file that was distributed with this source code.
                             <tbody>
                             {% for client in clients %}
                                 <tr id="client-{{ client.identifier }}">
+                                    <td class="align-middle text-center ps-3">{{ client.name }}</td>
                                     <td class="align-middle text-center ps-3">
                                         <input type="text" class="form-control copy-secret" value="{{ client.identifier }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
                                     </td>
                                     <td class="align-middle text-center">
-                                        <input type="text" class="form-control copy-secret" value="{{ client.Secret }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
+                                        {%- if client.identifier in agentCommerceClientIds -%}
+                                            {# 発行直後の画面でのみ平文を提示する (一覧の保存値は初回利用後にハッシュへ変わる) #}
+                                            <span class="text-muted" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.agent_commerce.secret_hidden_tooltip'|trans }}">-</span>
+                                        {%- elseif client.Secret is empty -%}
+                                            {# public client (DCR 登録等) はシークレットを持たない #}
+                                            <span class="text-muted" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.secret_none_tooltip'|trans }}">-</span>
+                                        {%- else -%}
+                                            <input type="text" class="form-control copy-secret" value="{{ client.Secret }}" data-tooltip="true" data-placement="top" title="{{ 'api.admin.oauth.copy'|trans }}" readonly>
+                                        {%- endif -%}
                                     </td>
                                     <td class="align-middle text-center ps-3">
                                         {% for scope in client.scopes %}

--- a/Security/AgentCommerceAccessTokenHandler.php
+++ b/Security/AgentCommerceAccessTokenHandler.php
@@ -32,6 +32,12 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
  * 付与 scope は {@link UserBadge} の attributes に `scopes` (array<string>) として載せる。
  * 本体はこの attributes から scope を取り出し ScopeRegistry で protocol×capability を照合する。
  * subject (UserBadge identifier) は OAuth2 クライアント識別子 (client_credentials のため会員は伴わない)。
+ *
+ * **`role_prefix: ROLE_OAUTH2_` による scope → role 変換は経由しない**。 返す InMemoryUser には
+ * `ROLE_OAUTH2_CLIENT` だけを載せるため、 `ROLE_OAUTH2_ACP:CHECKOUT` のようなロールは生成されない。
+ * GraphQL / MCP 経路は role ベースで認可するのに対し、 エージェントコマースは attributes の scope を
+ * 本体が直接照合する流儀になる。 `access_control` や `is_granted()` で `ROLE_OAUTH2_<SCOPE>` を
+ * 期待しないこと (認可は本体の AgentCommerceOAuth2Authenticator 側にある)。
  */
 final class AgentCommerceAccessTokenHandler implements AccessTokenHandlerInterface
 {

--- a/Security/AgentCommerceAccessTokenHandler.php
+++ b/Security/AgentCommerceAccessTokenHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Security;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\ResourceServer;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+/**
+ * エージェントコマース (ACP/UCP) のインバウンド OAuth2 Bearer トークンを検証する
+ * Symfony 標準 {@link AccessTokenHandlerInterface} の実装 (eccube-api4#188)。
+ *
+ * EC-CUBE 本体の AgentCommerceOAuth2Authenticator はこの口にのみ依存し (具象 api4 には非依存)、
+ * 本ハンドラが league の {@link ResourceServer} を用いて Bearer トークン (JWT) を検証する:
+ * 公開鍵による署名検証・有効期限・失効 (AccessTokenRepository) を league がまとめて担保する。
+ *
+ * 付与 scope は {@link UserBadge} の attributes に `scopes` (array<string>) として載せる。
+ * 本体はこの attributes から scope を取り出し ScopeRegistry で protocol×capability を照合する。
+ * subject (UserBadge identifier) は OAuth2 クライアント識別子 (client_credentials のため会員は伴わない)。
+ */
+final class AgentCommerceAccessTokenHandler implements AccessTokenHandlerInterface
+{
+    public function __construct(
+        private readonly ResourceServer $resourceServer,
+        private readonly ServerRequestFactoryInterface $serverRequestFactory,
+    ) {
+    }
+
+    public function getUserBadgeFrom(string $accessToken): UserBadge
+    {
+        // league の ResourceServer は PSR-7 リクエスト前提のため、Authorization ヘッダだけ持つ
+        // 最小のリクエストを組み立てて検証に通す。
+        $request = $this->serverRequestFactory
+            ->createServerRequest('GET', 'https://localhost/')
+            ->withHeader('Authorization', 'Bearer '.$accessToken);
+
+        try {
+            $validated = $this->resourceServer->validateAuthenticatedRequest($request);
+        } catch (OAuthServerException $e) {
+            // 署名不正・期限切れ・失効・形式不正はすべて認証失敗 (401) に正規化する。
+            throw new BadCredentialsException('Invalid OAuth2 access token.', 0, $e);
+        }
+
+        $clientId = (string) ($validated->getAttribute('oauth_client_id') ?? '');
+
+        $rawScopes = $validated->getAttribute('oauth_scopes');
+        $scopes = is_array($rawScopes)
+            ? array_values(array_map(static fn ($scope): string => (string) $scope, $rawScopes))
+            : [];
+
+        return new UserBadge(
+            '' !== $clientId ? $clientId : 'oauth2-client',
+            // client_credentials は会員を伴わないため、provider 探索を避けて軽量ユーザーを返す。
+            // 本体は identifier と attributes のみ参照するが、getUser() 呼び出しにも備える。
+            static fn (string $identifier): InMemoryUser => new InMemoryUser($identifier, null, ['ROLE_OAUTH2_CLIENT']),
+            ['scopes' => $scopes],
+        );
+    }
+}

--- a/Tests/Security/AgentCommerceAccessTokenHandlerTest.php
+++ b/Tests/Security/AgentCommerceAccessTokenHandlerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Security;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\ResourceServer;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Plugin\Api44\Security\AgentCommerceAccessTokenHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
+/**
+ * {@link AgentCommerceAccessTokenHandler} のユニットテスト (#188)。
+ *
+ * league の {@link ResourceServer} はモックし、検証成功時に付与 scope が UserBadge へ
+ * 正しく載ること・検証失敗 (OAuthServerException) が BadCredentialsException に正規化される
+ * ことを確認する (実トークンでの E2E は本体側 Job B が担当)。
+ */
+class AgentCommerceAccessTokenHandlerTest extends TestCase
+{
+    private Psr17Factory $psr17Factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->psr17Factory = new Psr17Factory();
+    }
+
+    public function testReturnsUserBadgeWithClientIdAndScopes(): void
+    {
+        $validated = $this->psr17Factory->createServerRequest('GET', 'https://localhost/')
+            ->withAttribute('oauth_client_id', 'acp-client-1')
+            ->withAttribute('oauth_scopes', ['acp:checkout', 'acp:catalog']);
+
+        $handler = $this->createHandlerReturning($validated);
+        $badge = $handler->getUserBadgeFrom('valid-jwt');
+
+        self::assertSame('acp-client-1', $badge->getUserIdentifier(), 'subject は OAuth2 クライアント識別子');
+        self::assertSame(
+            ['acp:checkout', 'acp:catalog'],
+            $badge->getAttributes()['scopes'],
+            '付与 scope は UserBadge attributes の scopes に array で載る'
+        );
+    }
+
+    public function testFallsBackToPlaceholderIdentifierWhenClientIdMissing(): void
+    {
+        $validated = $this->psr17Factory->createServerRequest('GET', 'https://localhost/')
+            ->withAttribute('oauth_scopes', ['ucp:checkout']);
+
+        $handler = $this->createHandlerReturning($validated);
+        $badge = $handler->getUserBadgeFrom('valid-jwt');
+
+        self::assertSame('oauth2-client', $badge->getUserIdentifier());
+        self::assertSame(['ucp:checkout'], $badge->getAttributes()['scopes']);
+    }
+
+    public function testReturnsEmptyScopesWhenAttributeMissing(): void
+    {
+        $validated = $this->psr17Factory->createServerRequest('GET', 'https://localhost/')
+            ->withAttribute('oauth_client_id', 'acp-client-1');
+
+        $handler = $this->createHandlerReturning($validated);
+        $badge = $handler->getUserBadgeFrom('valid-jwt');
+
+        self::assertSame([], $badge->getAttributes()['scopes'], 'scope クレームが無ければ空配列');
+    }
+
+    public function testThrowsBadCredentialsWhenTokenInvalid(): void
+    {
+        $resourceServer = $this->createMock(ResourceServer::class);
+        $resourceServer->method('validateAuthenticatedRequest')
+            ->willThrowException(OAuthServerException::accessDenied('invalid token'));
+
+        $handler = new AgentCommerceAccessTokenHandler($resourceServer, $this->psr17Factory);
+
+        $this->expectException(BadCredentialsException::class);
+        $handler->getUserBadgeFrom('expired-or-tampered-jwt');
+    }
+
+    private function createHandlerReturning(ServerRequestInterface $validated): AgentCommerceAccessTokenHandler
+    {
+        $resourceServer = $this->createMock(ResourceServer::class);
+        $resourceServer->method('validateAuthenticatedRequest')->willReturn($validated);
+
+        return new AgentCommerceAccessTokenHandler($resourceServer, $this->psr17Factory);
+    }
+}

--- a/Tests/Web/Admin/AgentCommerceClientControllerTest.php
+++ b/Tests/Web/Admin/AgentCommerceClientControllerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\Api44\Tests\Web\Admin;
+
+use Eccube\Tests\Web\Admin\AbstractAdminWebTestCase;
+use League\Bundle\OAuth2ServerBundle\Model\Client;
+use League\Bundle\OAuth2ServerBundle\OAuth2Grants;
+use Plugin\Api44\Form\Type\Admin\AgentCommerceClientType;
+
+/**
+ * エージェントコマース (ACP/UCP) 用クライアント登録の契約テスト。
+ *
+ * grant が client_credentials に固定され、 protocol を跨いだ scope や
+ * 会員同意が前提の scope (ucp:identity) を付与できないことを担保する。
+ */
+class AgentCommerceClientControllerTest extends AbstractAdminWebTestCase
+{
+    public function testAcpFormOffersOnlyAcpScopes(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_api_oauth_acp_new'));
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertSame(
+            ['acp:checkout', 'acp:catalog'],
+            $this->scopeChoices($crawler),
+            'ACP の画面には acp: の scope だけを提示する'
+        );
+    }
+
+    public function testUcpFormExcludesIdentityScope(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_api_oauth_ucp_new'));
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        // ucp:identity は Customer subject の authorization_code が前提 (eccube-api4#189) のため提示しない
+        $this->assertSame(['ucp:checkout', 'ucp:cart', 'ucp:catalog'], $this->scopeChoices($crawler));
+    }
+
+    public function testFormHasNoRedirectUriAndGrantChoice(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_api_oauth_acp_new'));
+
+        // grant は client_credentials 固定、 redirect_uri は不使用なので入力させない
+        $this->assertCount(0, $crawler->filter('input[name="api_admin_agent_commerce_client[redirect_uris]"]'));
+        $this->assertCount(0, $crawler->filter('input[name^="api_admin_agent_commerce_client[grants]"]'));
+    }
+
+    public function testCreateAcpClientFixesGrantToClientCredentials(): void
+    {
+        $identifier = 'acptestclient'.random_int(1000, 9999);
+        $this->submitCreate('admin_api_oauth_acp_new', $identifier, ['acp:checkout'], 'ChatGPT');
+
+        $client = $this->findClient($identifier);
+
+        $this->assertNotNull($client, 'ACP クライアントが登録されること');
+        $this->assertSame('ChatGPT', $client->getName(), 'どの事業者向けかを一覧で追えるよう名称を保持する');
+        $this->assertSame(
+            [OAuth2Grants::CLIENT_CREDENTIALS],
+            array_map(strval(...), $client->getGrants()),
+            'grant は client_credentials に固定される (authorization_code / refresh_token を持たない)'
+        );
+        $this->assertSame(['acp:checkout'], array_map(strval(...), $client->getScopes()));
+    }
+
+    public function testCreateShowsSecretOnceAndNotInList(): void
+    {
+        $identifier = 'acpsecretclient'.random_int(1000, 9999);
+        $secret = 'acponetimesecret';
+
+        $crawler = $this->client->request('POST', $this->generateUrl('admin_api_oauth_acp_new'), [
+            'api_admin_agent_commerce_client' => [
+                'name' => 'ChatGPT',
+                'identifier' => $identifier,
+                'secret' => $secret,
+                'scopes' => ['acp:checkout'],
+                '_token' => 'dummy',
+            ],
+        ]);
+
+        // 発行直後の画面でだけ平文を提示する (redirect すると失われる)
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertSame($secret, trim($crawler->filter('#agent_commerce_client_secret')->text()));
+        $this->assertStringContainsString(
+            'no-store',
+            (string) $this->client->getResponse()->headers->get('Cache-Control'),
+            '認証情報を含む画面はキャッシュさせない'
+        );
+
+        // 一覧では再表示しない (league が初回利用時に保存値をハッシュへ差し替えるため)
+        $crawler = $this->client->request('GET', $this->generateUrl('admin_api_oauth'));
+        $row = $crawler->filter('#client-'.$identifier);
+        $this->assertCount(1, $row);
+        $this->assertStringNotContainsString($secret, $row->html());
+        $this->assertCount(0, $row->filter('input.copy-secret[value="'.$secret.'"]'));
+    }
+
+    public function testCreateRejectsScopeOfAnotherProtocol(): void
+    {
+        $identifier = 'acpcrossclient'.random_int(1000, 9999);
+        // ACP の導線へ UCP の scope を送り込む (フォームバイパス)
+        $this->submitCreate('admin_api_oauth_acp_new', $identifier, ['ucp:checkout']);
+
+        $this->assertNull($this->findClient($identifier), 'protocol を跨いだ scope では登録されない');
+    }
+
+    public function testIdentityScopeIsNotGrantableFromThisFlow(): void
+    {
+        $identifier = 'ucpidentityclient'.random_int(1000, 9999);
+        $this->submitCreate('admin_api_oauth_ucp_new', $identifier, ['ucp:identity']);
+
+        $this->assertNull(
+            $this->findClient($identifier),
+            'ucp:identity は会員同意 (Customer authorization_code) が前提のため client_credentials では付与できない'
+        );
+        $this->assertNotContains('ucp:identity', AgentCommerceClientType::PROTOCOL_SCOPES['ucp']);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scopeChoices(\Symfony\Component\DomCrawler\Crawler $crawler): array
+    {
+        return $crawler->filter('input[name="api_admin_agent_commerce_client[scopes][]"]')
+            ->each(static fn (\Symfony\Component\DomCrawler\Crawler $node): string => (string) $node->attr('value'));
+    }
+
+    /**
+     * @param list<string> $scopes
+     */
+    private function submitCreate(string $route, string $identifier, array $scopes, string $name = 'agent'): void
+    {
+        $this->client->request('POST', $this->generateUrl($route), [
+            'api_admin_agent_commerce_client' => [
+                'name' => $name,
+                'identifier' => $identifier,
+                'secret' => 'agentclientsecret',
+                'scopes' => $scopes,
+                '_token' => 'dummy',
+            ],
+        ]);
+    }
+
+    private function findClient(string $identifier): ?Client
+    {
+        // Web リクエスト側で永続化されたクライアントを読むため、 テスト側の identity map を捨てる
+        $this->entityManager->clear();
+
+        return $this->entityManager->getRepository(Client::class)->findOneBy(['identifier' => $identifier]);
+    }
+}

--- a/Tests/Web/Admin/AgentCommerceClientControllerTest.php
+++ b/Tests/Web/Admin/AgentCommerceClientControllerTest.php
@@ -26,6 +26,11 @@ use Plugin\Api44\Form\Type\Admin\AgentCommerceClientType;
  */
 class AgentCommerceClientControllerTest extends AbstractAdminWebTestCase
 {
+    /**
+     * 制約を満たす最小長 (32 文字) のシークレット。 既定値は sha512 hex (128 文字)。
+     */
+    private const VALID_SECRET = 'agentclientsecret0123456789abcde';
+
     public function testAcpFormOffersOnlyAcpScopes(): void
     {
         $crawler = $this->client->request('GET', $this->generateUrl('admin_api_oauth_acp_new'));
@@ -76,7 +81,7 @@ class AgentCommerceClientControllerTest extends AbstractAdminWebTestCase
     public function testCreateShowsSecretOnceAndNotInList(): void
     {
         $identifier = 'acpsecretclient'.random_int(1000, 9999);
-        $secret = 'acponetimesecret';
+        $secret = 'acponetimesecret0123456789abcdef';
 
         $crawler = $this->client->request('POST', $this->generateUrl('admin_api_oauth_acp_new'), [
             'api_admin_agent_commerce_client' => [
@@ -114,6 +119,17 @@ class AgentCommerceClientControllerTest extends AbstractAdminWebTestCase
         $this->assertNull($this->findClient($identifier), 'protocol を跨いだ scope では登録されない');
     }
 
+    public function testCreateRejectsTooShortSecret(): void
+    {
+        $identifier = 'acpweaksecret'.random_int(1000, 9999);
+        $this->submitCreate('admin_api_oauth_acp_new', $identifier, ['acp:checkout'], 'agent', 'short');
+
+        $this->assertNull(
+            $this->findClient($identifier),
+            'client_credentials ではシークレットが唯一の認証情報なので、 短いシークレットでは登録させない'
+        );
+    }
+
     public function testIdentityScopeIsNotGrantableFromThisFlow(): void
     {
         $identifier = 'ucpidentityclient'.random_int(1000, 9999);
@@ -138,13 +154,13 @@ class AgentCommerceClientControllerTest extends AbstractAdminWebTestCase
     /**
      * @param list<string> $scopes
      */
-    private function submitCreate(string $route, string $identifier, array $scopes, string $name = 'agent'): void
+    private function submitCreate(string $route, string $identifier, array $scopes, string $name = 'agent', string $secret = self::VALID_SECRET): void
     {
         $this->client->request('POST', $this->generateUrl($route), [
             'api_admin_agent_commerce_client' => [
                 'name' => $name,
                 'identifier' => $identifier,
-                'secret' => 'agentclientsecret',
+                'secret' => $secret,
                 'scopes' => $scopes,
                 '_token' => 'dummy',
             ],

--- a/Tests/Web/Admin/OAuthControllerTest.php
+++ b/Tests/Web/Admin/OAuthControllerTest.php
@@ -89,6 +89,9 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
         $this->expected = $formData['identifier'];
         $this->verify();
 
+        // 一覧で用途を識別できるよう名称を保持する
+        $this->assertSame($formData['name'], $client->getName());
+
         $scopes = $client->getScopes();
         $this->assertTrue(in_array('read', $scopes));
         $this->assertTrue(in_array('write', $scopes));
@@ -145,6 +148,7 @@ class OAuthControllerTest extends AbstractAdminWebTestCase
     {
         return [
             '_token' => 'dummy',
+            'name' => 'stock sync batch',
             'identifier' => hash('md5', random_bytes(16)),
             'secret' => hash('sha512', random_bytes(32)),
             'scopes' => ['read', 'write'],


### PR DESCRIPTION
## 概要

AI エージェント (ChatGPT / Gemini 等) → EC-CUBE のインバウンド machine-to-machine 認証を成立させるため、OAuth2 の **client_credentials グラントを有効化**し、エージェントコマース (ACP/UCP) 用の **scope を登録**します。あわせて、EC-CUBE 本体の `AgentCommerceOAuth2Authenticator` が依存する Symfony 標準 `AccessTokenHandlerInterface` の具象と、**ACP/UCP 用クライアントの登録導線**を提供します。

Closes #188

## 変更内容

### 認証基盤

- **client_credentials グラント有効化** (`Resource/config/services.yaml`)。
- **agentic scope 登録**: `<protocol>:<capability>` 規約で 6 scope を `scopes.available` に追加 (`acp:checkout` / `acp:catalog` / `ucp:checkout` / `ucp:cart` / `ucp:catalog` / `ucp:identity`)。`default` は `read` のまま (明示要求時のみ付与)。
- **`Plugin\Api44\Security\AgentCommerceAccessTokenHandler`** (新規): league の `ResourceServer` で Bearer トークン (JWT) を検証 (公開鍵署名・有効期限・失効) し、付与 scope を Symfony の `UserBadge` attributes (`scopes`) に載せて返す。`Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface` を alias で束ね、本体の `AgentCommerceOAuth2Authenticator` が `@?` optional 依存で解決する (api4 未導入時は本体が 503 を返す疎結合)。

### 管理画面: ACP/UCP クライアントの登録導線を分離

汎用の OAuth クライアント登録フォームに scope と grant を並べるだけでは、**成立しない組み合わせ**を作れてしまいます (例: `acp:checkout` × authorization_code、会員同意が前提の `ucp:identity` × client_credentials)。また 1 クライアントに ACP と UCP を混在させると、受注に記録される `Order.agent_id` (= クライアント識別子) から事業者を特定できず、失効・監査を事業者単位で行えません。そこで**登録導線自体を protocol ごとに分離**しました。

- 「**ACP 新規追加**」「**UCP 新規追加**」ボタンと専用画面を追加 (`AgentCommerceClientController` / `AgentCommerceClientType`)。grant は **client_credentials 固定**、scope は当該 protocol のものだけを提示、リダイレクト URI は入力させない。
- **`ucp:identity` はこの導線から除外**。Customer を subject とする authorization_code が前提で client_credentials では成立しないため (#189)。#189 に[必要な追加実装をコメント済み](https://github.com/EC-CUBE/eccube-api4/issues/189#issuecomment-5188099770)。
- 汎用フォーム (`ClientType`) は GraphQL 用に戻し、`acp:`/`ucp:` と client_credentials の選択肢を持たせない。
- クライアントに**名称**を持たせ (`Client::name`)、一覧に名称列を追加。汎用フォームにも名称欄を追加 (従来は空文字固定)。

### 管理画面: クライアントシークレットの扱い

league は**保存時にハッシュ化せず、初回のトークン取得成功時に bcrypt へ日和見アップグレード**します (`ClientRepository::validateClient`)。そのため一覧に表示される値は、一度使われた後は事業者へ渡せないハッシュになります。

- 登録直後に**シークレットを 1 度だけ表示する完了画面**を追加 (`Cache-Control: no-store, private`)。登録画面にもその旨を明記。
- 一覧では ACP/UCP 用クライアントのシークレットを再表示せず `-` 表示 (理由をツールチップで提示)。public client (DCR 登録等) も同様に `-` 表示に統一。
- 列追加に伴い一覧の列幅を `<colgroup>` で明示 (見出しの折り返し解消)。

### テスト

- `AgentCommerceAccessTokenHandlerTest`: scope 付与 / 不正トークンの `BadCredentialsException` 正規化。
- `AgentCommerceClientControllerTest`: protocol 別の scope 提示 / grant が client_credentials に固定される / protocol を跨いだ scope はフォームバイパスでも拒否 / `ucp:identity` は付与不可 / 完了画面で平文を 1 度だけ提示し `no-store` が付く / 一覧にシークレットが出ない。
- `OAuthControllerTest`: 名称の永続化を追加。

## 設計メモ

- 本体は api4 の具象クラスに依存せず、Symfony 標準 `AccessTokenHandlerInterface` のみに依存する疎結合設計。本 PR がその口を提供する。
- MCP の PR (#190) はマージ済みで、本ブランチは upstream/4.4 を取り込み済み。`scopes.available` は MCP read 4 件と agentic 6 件が共存する。**MCP discovery の `scopes_supported` は `McpTokenService::AVAILABLE_SCOPES` を唯一のソースにしているため、agentic scope の追加による汚染はない**。
- 公開 DCR (`POST /register`) は grant を `authorization_code`+`refresh_token`、scope を MCP read にハードクランプするため、client_credentials を全体で有効化しても**匿名登録クライアントが machine トークンを取得することはない**。
- 会員 ID 連携 (authorization_code / `ucp:identity`) は #189 の範囲。

## 検証

ローカルで **EC-CUBE 4.4 + 本 PR の api44 + sample-payment-plugin** を共存させ、HTTPS (symfony CLI) 上で確認しました。

- **ACP/UCP チェックアウト E2E**: 管理画面の「ACP 新規追加」から登録したクライアントで `POST /token` (client_credentials) → 実 JWT を取得 → `e2e/agent/acp-checkout.php` **PASS (31 assertions)** / `e2e/agent/ucp-checkout.php` **PASS (23 assertions)**。3DS 中断・再開、決済拒否を含む complete まで通過し、受注の `agent_protocol` / `agent_id` が期待どおり記録されることを確認。
- **scope 越境の拒否**: ACP クライアントで `ucp:checkout` を要求すると `invalid_scope`。
- **MCP との共存**: 本体 MCP (EC-CUBE/ec-cube#6832) をローカルにマージした環境で、OAuth 自動ディスカバリ (RFC 9728 → RFC 8414 → DCR → authorization_code + PKCE) のみで MCP セッションを確立し `tools/list` (11 ツール) / `tools/call` まで到達。refresh_token のローテーションと旧トークン失効も確認。エージェントコマース側の E2E もこの状態で PASS。
- **管理画面**: 各画面をブラウザ (playwright) で描画確認。ツールチップの実表示を DOM で実測、コンソールエラー・警告 0 件。
- **静的解析 / テスト**: PHPStan level 6 `No errors` / PHPUnit **127 tests, 342 assertions, 0 failures** (deprecation 3 件はいずれも既存コード由来)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
